### PR TITLE
[minor] error handling of mandatory definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,14 @@ class Struct extends ResolvedType {
       this.flagsPosition = description.flagsPosition
     }
 
+    if (!description.name) {
+      throw new Error(`Struct ${this.fqn}: required 'name' definition is missing`)
+    }
+
+    if (!description.fields) {
+      throw new Error(`Struct ${this.fqn}: required 'fields' definition is missing`)
+    }
+
     if (this.existing) {
       const oldLength = this.existing.fields.length
       const newLength = this.description.fields.length


### PR DESCRIPTION
When building an incomplete schema: `name`, `fields`

Current

```bash
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
    at new Struct (file:///Users/user/holepunch/pear/node_modules/hyperschema/index.js:154:44)
    at Hyperschema.register (file:///Users/user/holepunch/pear/node_modules/hyperschema/index.js:238:14)
    at HyperschemaNamespace.register (file:///Users/user/holepunch/pear/node_modules/hyperschema/index.js:189:29)
...
```

This PR

```bash
Uncaught Error: Struct @pear/bundle: required 'fields' definition is missing
    at new Struct (file:///Users/user/holepunch/pear/node_modules/hyperschema/index.js:146:13)
    at Hyperschema.register (file:///Users/user/holepunch/pear/node_modules/hyperschema/index.js:246:14)
    at HyperschemaNamespace.register (file:///Users/user/holepunch/pear/node_modules/hyperschema/index.js:197:29)
...
```