### PR TITLE
support external types

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -1,10 +1,11 @@
 const gen = require('generate-object-property')
 const s = require('generate-string')
 
-module.exports = function generateSchema (hyperschema, { esm = false } = {}) {
+module.exports = function generateSchema (hyperschema, { esm = false, filename } = {}) {
   const structs = []
   const structsByName = new Map()
   const deferred = []
+  const externalStructs = new Map()
 
   for (let i = 0; i < hyperschema.schema.length; i++) {
     const fqn = hyperschema.typesByPosition.get(i)
@@ -18,6 +19,9 @@ module.exports = function generateSchema (hyperschema, { esm = false } = {}) {
     if (type.isEnum) {
       structs.push(type)
     }
+    if (type.isExternal) {
+      structs.push(type)
+    }
   }
 
   for (let i = 0; i < structs.length; i++) {
@@ -29,7 +33,22 @@ module.exports = function generateSchema (hyperschema, { esm = false } = {}) {
   for (let i = 0; i < structs.length; i++) {
     const struct = structs[i]
     const result = structsByName.get(struct.fqn)
-    result.encoder = struct.enum ? generateEnum(result.id, struct) : generateStruct(result.id, struct, deferred)
+
+    if (struct.isExternal) {
+      if (!filename) throw new Error('Must provide filename if using external types')
+      const req = struct.require(filename)
+      let v = externalStructs.get(req)
+      if (!v) {
+        v = 'external' + externalStructs.size + '_get_struct'
+        externalStructs.set(req, v)
+      }
+      result.encoder = `const ${result.id} = ${v}(${s(struct.fqn)})\n`
+      continue
+    }
+
+    result.encoder = struct.isEnum
+      ? generateEnum(result.id, struct)
+      : generateStruct(result.id, struct, deferred)
   }
 
   let str = ''
@@ -45,6 +64,13 @@ module.exports = function generateSchema (hyperschema, { esm = false } = {}) {
     str += 'import { c } from \'hyperschema/runtime\'\n'
   } else {
     str += 'const { c } = require(\'hyperschema/runtime\')\n'
+  }
+  for (const [req, v] of externalStructs) {
+    if (esm) {
+      str += `import { getStruct as ${v} } from ${s(req)}\n`
+    } else {
+      str += `const ${v} = require(${s(req)}).getStruct\n`
+    }
   }
 
   str += '\n'


### PR DESCRIPTION
ie

```
ns.register({
  name: 'my-custom-type',
  external: './file/that/has/getStruct/export.js'
})
```

When the code is required, it would call `getStruct(fqn)` on the above file expecting to get the requested struct back. Doing it this also allows you to chain generated schemas in addition to allowing "hand rolled" encoders