### PR TITLE
Make top level register a private method

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -355,7 +355,7 @@ class HyperschemaNamespace {
   }
 
   register (description) {
-    return this.hyperschema.register({
+    return this.hyperschema._register({
       ...description,
       namespace: this.name
     })
@@ -379,7 +379,7 @@ module.exports = class Hyperschema {
     if (json) {
       for (let i = 0; i < json.schema.length; i++) {
         const description = json.schema[i]
-        this.register(description)
+        this._register(description)
       }
     }
     this.initializing = false
@@ -404,6 +404,13 @@ module.exports = class Hyperschema {
   }
 
   register (description) {
+    return this._register({
+      ...description,
+      namespace: null
+    })
+  }
+
+  _register (description) {
     const fqn = this._getFullyQualifiedName(description)
     const existing = this.types.get(fqn)
     const existingPosition = this.positionsByType.get(fqn)

--- a/builder.cjs
+++ b/builder.cjs
@@ -239,10 +239,6 @@ class Array extends ResolvedType {
       throw new Error(`Array ${this.fqn}: required 'name' definition is missing`)
     }
 
-    if (!description.namespace) {
-      throw new Error(`Array ${this.fqn}: required 'namespace' definition is missing`)
-    }
-
     if (this.existing) {
       if (this.existing.type.fqn !== this.type.fqn) {
         throw new Error(`Array was modified: ${this.fqn}`)

--- a/builder.cjs
+++ b/builder.cjs
@@ -239,6 +239,10 @@ class Array extends ResolvedType {
       throw new Error(`Array ${this.fqn}: required 'name' definition is missing`)
     }
 
+    if (!description.namespace) {
+      throw new Error(`Array ${this.fqn}: required 'namespace' definition is missing`)
+    }
+
     if (this.existing) {
       if (this.existing.type.fqn !== this.type.fqn) {
         throw new Error(`Array was modified: ${this.fqn}`)
@@ -397,13 +401,6 @@ module.exports = class Hyperschema {
 
   linkAll () {
     for (const t of this.types.values()) t.link()
-  }
-
-  register (description) {
-    return this._register({
-      ...description,
-      namespace: null
-    })
   }
 
   _register (description) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -481,3 +481,39 @@ test('basic enums (strings)', async t => {
 
   t.alike(schema.module.getEnum('@test/test-enum'), { hello: 'hello', world: 'world' })
 })
+
+test('basic no namespace', async t => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(schema => {
+    schema.register({
+      name: 'value',
+      fields: [
+        {
+          name: 'test',
+          type: 'uint',
+          required: true
+        }
+      ]
+    })
+
+    schema.register({
+      name: 'optionalValue',
+      fields: [
+        {
+          name: 'value',
+          type: 'value',
+          required: false
+        }
+      ]
+    })
+  })
+
+  {
+    const enc = schema.module.resolveStruct('optionalValue')
+    const buf = c.encode(enc, { value: { test: 1 } })
+    const dec = c.decode(enc, buf)
+
+    t.alike(dec, { value: { test: 1 } })
+  }
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -481,39 +481,3 @@ test('basic enums (strings)', async t => {
 
   t.alike(schema.module.getEnum('@test/test-enum'), { hello: 'hello', world: 'world' })
 })
-
-test('basic no namespace', async t => {
-  const schema = await createTestSchema(t)
-
-  await schema.rebuild(schema => {
-    schema.register({
-      name: 'value',
-      fields: [
-        {
-          name: 'test',
-          type: 'uint',
-          required: true
-        }
-      ]
-    })
-
-    schema.register({
-      name: 'optionalValue',
-      fields: [
-        {
-          name: 'value',
-          type: 'value',
-          required: false
-        }
-      ]
-    })
-  })
-
-  {
-    const enc = schema.module.resolveStruct('optionalValue')
-    const buf = c.encode(enc, { value: { test: 1 } })
-    const dec = c.decode(enc, buf)
-
-    t.alike(dec, { value: { test: 1 } })
-  }
-})


### PR DESCRIPTION
This PR forwards namespace as null if types are registered on the top level schema.

Note: I had to drop the required namespace for array types to be consistent.

I'm not sure if this is intended to be supported or not, so if not I can change the PR to throw a meaningful error instead.