### PR TITLE
Fix typo for `.register()` so its clear it applies to namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ Persist the generated encodings for a Hyperschema instance (previously loaded wi
 #### `const ns = schema.namespace(name)`
 Return a new schema namespace. All structs/aliases for this namespace will be registered with the `@name` prefix. You can then reference these structs/aliases in subsequent definitions.
 
-#### `schema.register(definition)`
-Register a new schema/alias definition, as described in the Schema Definition section above.
+#### `ns.register(definition)`
+Register a new schema/alias definition on a namespace, as described in the Schema Definition section above.
 
 ### License
 Apache 2.0


### PR DESCRIPTION
Previously users could be confused and use a top-level `.register()` instead of on a namespace. This was fixed by making the top level method private in https://github.com/holepunchto/hyperschema/pull/25. This PR updates the docs so it's a namespace method explicitly.