### PR TITLE
disable es-lint import/first rule

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -58,6 +58,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
   str += `// Schema Version: ${hyperschema.version}\n`
   str += '/* eslint-disable camelcase */\n'
   str += '/* eslint-disable quotes */\n'
+  str += '/* eslint-disable import/first */\n'
   str += '\n'
   str += `const VERSION = ${hyperschema.version}\n`
 


### PR DESCRIPTION
This PR avoids lint failure caused by the VERSION constant at the top of the file https://github.com/holepunchto/hyperschema/blob/main/lib/codegen.js#L62