### PR TITLE
Add versioned structs

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -261,7 +261,7 @@ class Array extends ResolvedType {
   }
 }
 
-class Versioned extends ResolvedType {
+class VersionedType extends ResolvedType {
   constructor (hyperschema, fqn, description, existing) {
     super(hyperschema, fqn, description, existing)
     this.isVersioned = true
@@ -269,7 +269,7 @@ class Versioned extends ResolvedType {
     this.filename = hyperschema.namespaces.get(description.namespace)?.external || null
 
     if (!description.versioned) {
-      throw new Error(`Versioned ${this.fqn}: required 'versioned' definition is missing`)
+      throw new Error(`VersionedType ${this.fqn}: required 'versioned' definition is missing`)
     }
 
     this.versions = description.versioned.map(v => {
@@ -282,16 +282,16 @@ class Versioned extends ResolvedType {
     this.framed = true
 
     if (!description.name) {
-      throw new Error(`Versioned ${this.fqn}: required 'name' definition is missing`)
+      throw new Error(`VersionedType ${this.fqn}: required 'name' definition is missing`)
     }
 
     if (!description.namespace) {
-      throw new Error(`Versioned ${this.fqn}: required 'namespace' definition is missing`)
+      throw new Error(`VersionedType ${this.fqn}: required 'namespace' definition is missing`)
     }
 
     if (this.existing) {
       if (this.existing.type.fqn !== this.type.fqn) {
-        throw new Error(`Versioned was modified: ${this.fqn}`)
+        throw new Error(`VersionedType was modified: ${this.fqn}`)
       }
     }
   }
@@ -468,7 +468,7 @@ module.exports = class Hyperschema {
     } else if (description.external) {
       type = new ExternalType(this, fqn, description, existing)
     } else if (description.versioned) {
-      type = new Versioned(this, fqn, description, existing)
+      type = new VersionedType(this, fqn, description, existing)
     } else {
       type = new Struct(this, fqn, description, existing)
     }

--- a/builder.cjs
+++ b/builder.cjs
@@ -280,6 +280,10 @@ class VersionedType extends ResolvedType {
       }
     })
 
+    for (const v of this.versions) {
+      v.type.expectsVersion = true
+    }
+
     this.framed = true
 
     if (!description.name) {
@@ -316,6 +320,7 @@ class Struct extends ResolvedType {
     super(hyperschema, fqn, description, existing)
     this.isStruct = true
     this.default = null
+    this.expectVersion = false
 
     this.fields = []
     this.fieldsByName = new Map()

--- a/builder.cjs
+++ b/builder.cjs
@@ -268,11 +268,11 @@ class VersionedType extends ResolvedType {
     this.default = null
     this.filename = hyperschema.namespaces.get(description.namespace)?.external || null
 
-    if (!description.versioned) {
-      throw new Error(`VersionedType ${this.fqn}: required 'versioned' definition is missing`)
+    if (!description.versions) {
+      throw new Error(`VersionedType ${this.fqn}: required 'versions' definition is missing`)
     }
 
-    this.versions = description.versioned.map(v => {
+    this.versions = description.versions.map(v => {
       return {
         type: hyperschema.resolve(v.type),
         map: v.map || null
@@ -467,7 +467,7 @@ module.exports = class Hyperschema {
       type = new Array(this, fqn, description, existing)
     } else if (description.external) {
       type = new ExternalType(this, fqn, description, existing)
-    } else if (description.versioned) {
+    } else if (description.versions) {
       type = new VersionedType(this, fqn, description, existing)
     } else {
       type = new Struct(this, fqn, description, existing)

--- a/builder.cjs
+++ b/builder.cjs
@@ -310,7 +310,7 @@ class VersionedType extends ResolvedType {
     return {
       name: this.name,
       namespace: this.namespace,
-      versions: this.versions.map(version => ({ type: version.type.fqn, map: version.map }))
+      versions: this.versions.map(version => ({ type: version.type.fqn, map: version.map, version: version.version }))
     }
   }
 }

--- a/builder.cjs
+++ b/builder.cjs
@@ -266,6 +266,7 @@ class Versioned extends ResolvedType {
     super(hyperschema, fqn, description, existing)
     this.isVersioned = true
     this.default = null
+    this.filename = hyperschema.namespaces.get(description.namespace)?.external || null
 
     if (!description.versioned) {
       throw new Error(`Versioned ${this.fqn}: required 'versioned' definition is missing`)
@@ -274,7 +275,7 @@ class Versioned extends ResolvedType {
     this.versions = description.versioned.map(v => {
       return {
         type: hyperschema.resolve(v.type),
-        map: v.map
+        map: v.map || null
       }
     })
 
@@ -295,11 +296,16 @@ class Versioned extends ResolvedType {
     }
   }
 
+  require (filename) {
+    return p.relative(p.join(filename, '..'), p.resolve(this.filename))
+      .replaceAll('\\', '/')
+  }
+
   toJSON () {
     return {
       name: this.name,
       namespace: this.namespace,
-      versions: this.versions.map(version => version.type.toJSON())
+      versions: this.versions.map(version => ({ type: version.type.fqn, map: version.map }))
     }
   }
 }

--- a/builder.cjs
+++ b/builder.cjs
@@ -320,7 +320,7 @@ class Struct extends ResolvedType {
     super(hyperschema, fqn, description, existing)
     this.isStruct = true
     this.default = null
-    this.expectVersion = false
+    this.expectsVersion = false
 
     this.fields = []
     this.fieldsByName = new Map()

--- a/builder.cjs
+++ b/builder.cjs
@@ -275,6 +275,7 @@ class VersionedType extends ResolvedType {
     this.versions = description.versions.map(v => {
       return {
         type: hyperschema.resolve(v.type),
+        version: v.version,
         map: v.map || null
       }
     })

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -313,7 +313,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
       for (let i = 0; i < struct.versions.length; i++) {
         const version = struct.versions[i]
         str += `      case ${i}:\n`
-        str += `        ${getEncoder(version.type)}.${fn}(state, m)\n`
+        str += `        ${getEncoder(version.type)}.${fn}(state, m.data)\n`
         str += '        break\n'
       }
       str += '      default:\n'
@@ -334,9 +334,9 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
         if (version.map) {
           const v = requireExternal(struct, filename)
           str += `        const map = ${gen(v, version.map)}\n`
-          str += `        return { version: ${i}, ...map(decoded) }\n`
+          str += `        return { version: ${i}, data: map(decoded) }\n`
         } else {
-          str += `        return { version: ${i}, ...decoded }`
+          str += `        return { version: ${i}, data: decoded }`
         }
         str += '      }\n'
       }

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -314,7 +314,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
       for (let i = 0; i < struct.versions.length; i++) {
         const def = struct.versions[i]
         while (version <= def.version) str += `      case ${version++}:\n`
-        str += `        ${getEncoder(def.type)}.${fn}(state, m.data)\n`
+        str += `        ${getEncoder(def.type)}.${fn}(state, m)\n`
         str += '        break\n'
       }
       str += '      default:\n'
@@ -333,13 +333,13 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
         const def = struct.versions[i]
         while (version <= def.version) str += `\n      case ${version++}:`
         str += ' {\n'
-        str += `        const decoded = ${getEncoder(def.type)}.decode(state)\n`
+        str += `        const decoded = ${getEncoder(def.type)}.decode(state, version)\n`
         if (def.map) {
           const v = requireExternal(struct, filename)
           str += `        const map = ${gen(v, def.map)}\n`
-          str += '        return { version, data: map(decoded) }\n'
+          str += '        return map(decoded)\n'
         } else {
-          str += '        return { version, data: decoded }\n'
+          str += '        return decoded\n'
         }
         str += '      }'
       }
@@ -403,7 +403,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
       enc += '  encode (state, m) {\n'
       enc += `${encode.trimRight()}\n`
       enc += '  },\n'
-      enc += '  decode (state) {\n'
+      enc += `  decode (state${struct.expectsVersion ? ', version' : ''}) {\n`
       enc += `${decode.trimRight()}\n`
       enc += '  }\n'
       enc += '}'
@@ -519,6 +519,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
       }
 
       str += '    return {\n'
+      if (struct.expectsVersion) str += '      version,\n'
 
       for (let i = 0; i < struct.fields.length; i++) {
         const field = struct.fields[i]

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -498,6 +498,10 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
       let str = ''
       let seen = 0
 
+      if (struct.expectsVersion) {
+        str += '    if (version === undefined) version = c.uint.decode(state)\n'
+      }
+
       const pre = new Map()
       for (let i = 0; i < struct.fields.length; i++) {
         const field = struct.fields[i]

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -23,6 +23,9 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
     if (type.isExternal) {
       structs.push(type)
     }
+    if (type.isVersioned) {
+      structs.push(type)
+    }
   }
 
   for (let i = 0; i < structs.length; i++) {
@@ -49,7 +52,9 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
 
     result.encoder = struct.isEnum
       ? generateEnum(result.id, struct)
-      : generateStruct(result.id, struct, deferred)
+      : struct.isVersioned
+        ? generateVersioned(result.id, struct)
+        : generateStruct(result.id, struct, deferred)
   }
 
   let str = ''
@@ -265,6 +270,81 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
     }
 
     return typeStr
+  }
+
+  function generateVersioned (id, struct) {
+    let str = ''
+    let enc = ''
+
+    str += `// ${struct.fqn}\n`
+    str += ''
+
+    const preencode = generateEncode({ preencode: true })
+    const encode = generateEncode()
+    const decode = generateDecode()
+
+    enc += '{\n'
+    enc += '  preencode (state, m) {\n'
+    enc += `${preencode.trimRight()}\n`
+    enc += '  },\n'
+    enc += '  encode (state, m) {\n'
+    enc += `${encode.trimRight()}\n`
+    enc += '  },\n'
+    enc += '  decode (state) {\n'
+    enc += `${decode.trimRight()}\n`
+    enc += '  }\n'
+    enc += '}'
+
+    str += dedupConst(id, enc)
+
+    return str
+
+    function generateEncode ({ preencode = false } = {}) {
+      const fn = preencode ? 'preencode' : 'encode'
+      let str = ''
+      str += `    c.uint.${fn}(state, m.version)\n`
+      str += '    switch (m.version) {\n'
+      for (let i = 0; i < struct.versions.length; i++) {
+        const version = struct.versions[i]
+        str += `      case ${i}:\n`
+        str += `        ${getEncoder(version.type)}.${fn}(state, m)\n`
+        str += '        break\n'
+      }
+      str += '      default:\n'
+      str += '        throw new Error(\'Unsupported version\')\n'
+      str += '    }'
+
+      return str
+    }
+
+    function generateDecode () {
+      let str = ''
+      str += '    const version = c.uint.decode(state)\n'
+      str += '    switch (version) {\n'
+      for (let i = 0; i < struct.versions.length; i++) {
+        const version = struct.versions[i]
+        str += `      case ${i}: {\n`
+        str += `        const decoded = ${getEncoder(version.type)}.decode(state)\n`
+        if (version.map) {
+          str += `        const map = ${version.map.toString()}\n`
+          str += `        return { version: ${i}, ...map(decoded) }\n`
+        } else {
+          str += `        return { version: ${i}, ...decoded }`
+        }
+        str += '      }\n'
+      }
+      str += '      default:\n'
+      str += '        throw new Error(\'Unsupported version\')\n'
+      str += '    }'
+
+      return str
+    }
+
+    function getEncoder (type) {
+      if (type.isAlias) return getEncoder(type.type)
+      if (type.isPrimitive) return `c.${type.name}`
+      return structsByName.get(type.fqn).id
+    }
   }
 
   function generateStruct (id, struct, deferred) {

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -310,10 +310,11 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
       let str = ''
       str += `    c.uint.${fn}(state, m.version)\n`
       str += '    switch (m.version) {\n'
+      let version = 0
       for (let i = 0; i < struct.versions.length; i++) {
-        const version = struct.versions[i]
-        str += `      case ${i}:\n`
-        str += `        ${getEncoder(version.type)}.${fn}(state, m.data)\n`
+        const def = struct.versions[i]
+        while (version <= def.version) str += `      case ${version++}:\n`
+        str += `        ${getEncoder(def.type)}.${fn}(state, m.data)\n`
         str += '        break\n'
       }
       str += '      default:\n'
@@ -326,21 +327,23 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
     function generateDecode () {
       let str = ''
       str += '    const version = c.uint.decode(state)\n'
-      str += '    switch (version) {\n'
+      str += '    switch (version) {'
+      let version = 0
       for (let i = 0; i < struct.versions.length; i++) {
-        const version = struct.versions[i]
-        str += `      case ${i}: {\n`
-        str += `        const decoded = ${getEncoder(version.type)}.decode(state)\n`
-        if (version.map) {
+        const def = struct.versions[i]
+        while (version <= def.version) str += `\n      case ${version++}:`
+        str += ' {\n'
+        str += `        const decoded = ${getEncoder(def.type)}.decode(state)\n`
+        if (def.map) {
           const v = requireExternal(struct, filename)
-          str += `        const map = ${gen(v, version.map)}\n`
-          str += `        return { version: ${i}, data: map(decoded) }\n`
+          str += `        const map = ${gen(v, def.map)}\n`
+          str += '        return { version, data: map(decoded) }\n'
         } else {
-          str += `        return { version: ${i}, data: decoded }`
+          str += '        return { version, data: decoded }\n'
         }
-        str += '      }\n'
+        str += '      }'
       }
-      str += '      default:\n'
+      str += '\n      default:\n'
       str += '        throw new Error(\'Unsupported version\')\n'
       str += '    }'
 

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -6,7 +6,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
   const structsByName = new Map()
   const deferred = []
   const dedup = new Map()
-  const externalStructs = new Map()
+  const externals = new Map()
 
   for (let i = 0; i < hyperschema.schema.length; i++) {
     const fqn = hyperschema.typesByPosition.get(i)
@@ -39,13 +39,7 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
     const result = structsByName.get(struct.fqn)
 
     if (struct.isExternal) {
-      if (!filename) throw new Error('Must provide filename if using external types')
-      const req = struct.require(filename)
-      let v = externalStructs.get(req)
-      if (!v) {
-        v = 'external' + externalStructs.size
-        externalStructs.set(req, v)
-      }
+      const v = requireExternal(struct, filename)
       result.encoder = `const ${result.id} = ${gen(v, struct.external)}\n`
       continue
     }
@@ -64,14 +58,13 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
   str += '/* eslint-disable camelcase */\n'
   str += '/* eslint-disable quotes */\n'
   str += '\n'
-  str += `const VERSION = ${hyperschema.version}\n`
 
   if (esm) {
     str += 'import { c } from \'hyperschema/runtime\'\n'
   } else {
     str += 'const { c } = require(\'hyperschema/runtime\')\n'
   }
-  for (const [req, v] of externalStructs) {
+  for (const [req, v] of externals) {
     if (esm) {
       str += `import * as ${v} from ${s(req)}\n`
     } else {
@@ -80,6 +73,9 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
   }
 
   str += '\n'
+  str += `const VERSION = ${hyperschema.version}\n`
+  str += '\n'
+
   str += '// eslint-disable-next-line no-unused-vars\n'
   str += 'let version = VERSION\n'
   str += '\n'
@@ -165,6 +161,16 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
   }
 
   return str
+
+  function requireExternal (struct, filename) {
+    if (!filename) throw new Error('Must provide filename if using external types')
+    const req = struct.require(filename)
+    let v = externals.get(req)
+    if (v) return v
+    v = 'external' + externals.size
+    externals.set(req, v)
+    return v
+  }
 
   function generateEnum (id, struct) {
     let str = ''
@@ -326,7 +332,8 @@ module.exports = function generateSchema (hyperschema, { esm = false, filename }
         str += `      case ${i}: {\n`
         str += `        const decoded = ${getEncoder(version.type)}.decode(state)\n`
         if (version.map) {
-          str += `        const map = ${version.map.toString()}\n`
+          const v = requireExternal(struct, filename)
+          str += `        const map = ${gen(v, version.map)}\n`
           str += `        return { version: ${i}, ...map(decoded) }\n`
         } else {
           str += `        return { version: ${i}, ...decoded }`

--- a/test/basic.js
+++ b/test/basic.js
@@ -511,7 +511,7 @@ test('versioned struct', async t => {
 
     ns.register({
       name: 'versioned',
-      versioned: [
+      versions: [
         {
           version: 0,
           type: '@test/v0',

--- a/test/basic.js
+++ b/test/basic.js
@@ -518,7 +518,7 @@ test('versioned struct', async t => {
           map: 'map'
         },
         {
-          version: 1,
+          version: 2,
           type: '@test/v1'
         }
       ]
@@ -528,9 +528,11 @@ test('versioned struct', async t => {
   {
     const enc = schema.module.resolveStruct('@test/versioned')
     const expectedv0 = { version: 0, data: { value: 10 } }
-    const expected = { version: 1, data: { value: 10 } }
+    const expectedv1 = { version: 1, data: { value: 10 } }
+    const expected = { version: 2, data: { value: 10 } }
 
     t.alike(expectedv0, c.decode(enc, c.encode(enc, { version: 0, data: { value: '10' } })))
+    t.alike(expectedv1, c.decode(enc, c.encode(enc, { version: 1, data: { value: 10 } })))
     t.alike(expected, c.decode(enc, c.encode(enc, expected)))
   }
 })

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const c = require('compact-encoding')
+const path = require('path')
 
 const { createTestSchema } = require('./helpers')
 
@@ -482,11 +483,13 @@ test('basic enums (strings)', async t => {
   t.alike(schema.module.getEnum('@test/test-enum'), { hello: 'hello', world: 'world' })
 })
 
-test('versioned struct', async t => {
+test.solo('versioned struct', async t => {
   const schema = await createTestSchema(t)
 
   await schema.rebuild(schema => {
     const ns = schema.namespace('test')
+
+    ns.require(path.join(__dirname, 'helpers/external.js'))
 
     ns.register({
       name: 'v0',
@@ -510,10 +513,12 @@ test('versioned struct', async t => {
       name: 'versioned',
       versioned: [
         {
+          version: 0,
           type: '@test/v0',
-          map: function (m) { return { value: Number(m.value) } }
+          map: 'map'
         },
         {
+          version: 1,
           type: '@test/v1'
         }
       ]

--- a/test/basic.js
+++ b/test/basic.js
@@ -483,7 +483,7 @@ test('basic enums (strings)', async t => {
   t.alike(schema.module.getEnum('@test/test-enum'), { hello: 'hello', world: 'world' })
 })
 
-test.solo('versioned struct', async t => {
+test('versioned struct', async t => {
   const schema = await createTestSchema(t)
 
   await schema.rebuild(schema => {
@@ -527,10 +527,10 @@ test.solo('versioned struct', async t => {
 
   {
     const enc = schema.module.resolveStruct('@test/versioned')
-    const expectedv0 = { version: 0, value: 10 }
-    const expected = { version: 1, value: 10 }
+    const expectedv0 = { version: 0, data: { value: 10 } }
+    const expected = { version: 1, data: { value: 10 } }
 
-    t.alike(expectedv0, c.decode(enc, c.encode(enc, { version: 0, value: '10' })))
+    t.alike(expectedv0, c.decode(enc, c.encode(enc, { version: 0, data: { value: '10' } })))
     t.alike(expected, c.decode(enc, c.encode(enc, expected)))
   }
 })

--- a/test/basic.js
+++ b/test/basic.js
@@ -527,12 +527,12 @@ test('versioned struct', async t => {
 
   {
     const enc = schema.module.resolveStruct('@test/versioned')
-    const expectedv0 = { version: 0, data: { value: 10 } }
-    const expectedv1 = { version: 1, data: { value: 10 } }
-    const expected = { version: 2, data: { value: 10 } }
+    const expectedv0 = { version: 0, value: 10 }
+    const expectedv1 = { version: 1, value: 10 }
+    const expected = { version: 2, value: 10 }
 
-    t.alike(expectedv0, c.decode(enc, c.encode(enc, { version: 0, data: { value: '10' } })))
-    t.alike(expectedv1, c.decode(enc, c.encode(enc, { version: 1, data: { value: 10 } })))
+    t.alike(expectedv0, c.decode(enc, c.encode(enc, { version: 0, value: '10' })))
+    t.alike(expectedv1, c.decode(enc, c.encode(enc, { version: 1, value: 10 })))
     t.alike(expected, c.decode(enc, c.encode(enc, expected)))
   }
 })

--- a/test/helpers/external.js
+++ b/test/helpers/external.js
@@ -1,5 +1,6 @@
 exports.map = function (data) {
   return {
+    version: data.version,
     value: Number(data.value)
   }
 }

--- a/test/helpers/external.js
+++ b/test/helpers/external.js
@@ -1,0 +1,5 @@
+exports.map = function (data) {
+  return {
+    value: Number(data.value)
+  }
+}


### PR DESCRIPTION
This PR implements `VersionedType`, which can be passed an array of explicit types corresponding to given versions.

eg. 
```js
const ns = schema.namespace({
  name: 'example',
  external: './my-helpers.js'
})

ns.register({
  name: 'manifest1',
  fields: [...]
})

ns.register({
  name: 'manifest2',
  fields: [...]
})

ns.register({
  name: 'manifest3',
  fields: [...]
})

ns.register({
  name: 'manifest',
  versioned: [
    {
      type: '@example/manifest1',
      map: 'mapManifest1'
    },
    {
      type: '@example/manifest2',
      map: 'mapManifest2'
    },
    {
      type: '@example/manifest3'
    }
  ]
})
```