### PR TITLE
Fix useDefault not being persisted

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -245,6 +245,7 @@ class StructField {
       array: this.description.array,
       record: this.description.record,
       inline: this.description.inline,
+      useDefault: this.description.useDefault,
       type: this.typeFqn,
       version: this.version
     }


### PR DESCRIPTION
I noticed that useDefault is currently not being persisted, which causes issues especially when using hyperschema in combination with hrpc and/or hyperdispatch, both relying on the generated schema file. This fix just adds the useDefault flag to the data being persisted.