### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -26,7 +26,7 @@ const NumericTypes = new Set([
 ])
 const StringTypes = new Set(['string', 'utf8', 'ascii', 'hex'])
 const BigIntTypes = new Set(['bigint', 'biguint64', 'bigint64'])
-const ObjectTypes = new Set(['fixed32', 'fixed64', 'buffer', 'date'])
+const ObjectTypes = new Set(['fixed32', 'fixed64', 'buffer', 'optionalBuffer', 'date'])
 const BooleanTypes = new Set(['bool'])
 const NetworkTypes = new Set(['ip', 'ipv4', 'ipv6', 'ipAddress', 'ipv4Address', 'ipv6Address'])
 const SupportedTypes = new Set([

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "homepage": "https://github.com/holepunchto/hyperschema#readme",
   "dependencies": {
     "bare-fs": "^4.0.1",
-    "compact-encoding": "^2.19.0",
+    "compact-encoding": "^3.0.0",
     "generate-object-property": "^2.0.0",
     "generate-string": "^1.0.1"
   },


### PR DESCRIPTION
Should be a major bump as it inherits the breaking change of `compact-encoding@3.0.0`. IE `buffer` before isn't the same as `buffer` after the bump. Same for `binary`.