### PR TITLE
types: add builder.d.ts for the Hyperschema class

### DIFF
--- a/builder.d.ts
+++ b/builder.d.ts
@@ -1,0 +1,138 @@
+export = Hyperschema
+
+declare class Hyperschema {
+  constructor(json?: Hyperschema.SchemaJSON | null, opts?: Hyperschema.Options)
+
+  version: number
+  versioned: boolean
+  dir: string | null
+
+  register(description: Hyperschema.TypeDescription): Hyperschema.ResolvedType
+  namespace(name: string): Hyperschema.Namespace
+  resolve(fqn: string, opts?: { aliases?: boolean }): Hyperschema.ResolvedType
+  toJSON(): Hyperschema.SchemaJSON
+  toCode(opts?: Hyperschema.ToCodeOptions): string
+  linkAll(): void
+  maybeBumpVersion(): void
+
+  static esm: boolean
+
+  // Polymorphic `this` so subclasses get their own type back, matching the
+  // runtime's `new this(...)`: `SwiftHyperschema.from(null)` is a SwiftHyperschema.
+  static from<T extends typeof Hyperschema>(
+    this: T,
+    json?: string | Hyperschema.SchemaJSON | null,
+    opts?: Hyperschema.Options
+  ): InstanceType<T>
+
+  static toDisk(
+    hyperschema: Hyperschema,
+    dir?: string | null,
+    opts?: Hyperschema.ToDiskOptions
+  ): void
+  static toDisk(hyperschema: Hyperschema, opts?: Hyperschema.ToDiskOptions): void
+}
+
+declare namespace Hyperschema {
+  export interface Options {
+    dir?: string | null
+    versioned?: boolean
+  }
+
+  export interface ToCodeOptions {
+    esm?: boolean
+    filename?: string
+  }
+
+  export interface ToDiskOptions {
+    esm?: boolean
+  }
+
+  export interface SchemaJSON {
+    version: number
+    schema: object[]
+  }
+
+  export interface Namespace {
+    readonly name: string
+    external: string | null
+    require(filename: string): void
+    register(description: TypeDescription): ResolvedType
+  }
+
+  export interface FieldDescription {
+    name: string
+    type: string
+    required?: boolean
+    array?: boolean
+    inline?: boolean
+    useDefault?: boolean
+    version?: number
+  }
+
+  export interface EnumValue {
+    key: string
+    version?: number
+  }
+
+  export interface VersionMapping {
+    version: number
+    type: string
+    map?: string
+  }
+
+  // A single registration. The kind keys (alias / enum / array / record /
+  // versions / external) are mutually exclusive; with none present the
+  // description is a struct and `fields` is required.
+  export interface TypeDescription {
+    name: string
+    namespace?: string | null
+    version?: number
+
+    // struct
+    fields?: FieldDescription[]
+    compact?: boolean
+    flagsPosition?: number
+
+    // alias
+    alias?: string
+
+    // enum
+    enum?: Array<string | EnumValue>
+    offset?: number
+    strings?: boolean
+
+    // array
+    array?: boolean
+    type?: string
+
+    // record
+    record?: boolean
+    key?: string
+    value?: string
+
+    // versioned
+    versions?: VersionMapping[]
+
+    // external
+    external?: unknown
+  }
+
+  // The resolved type returned by `register` / `resolve`. Only the stable
+  // identity and discriminant fields are surfaced here.
+  export interface ResolvedType {
+    readonly name: string
+    readonly namespace: string
+    readonly fqn: string
+    readonly version: number
+    readonly isPrimitive: boolean
+    readonly isEnum: boolean
+    readonly isStruct: boolean
+    readonly isArray: boolean
+    readonly isRecord: boolean
+    readonly isAlias: boolean
+    readonly isExternal: boolean
+    readonly isVersioned: boolean
+    toJSON(): object
+  }
+}

--- a/builder.d.ts
+++ b/builder.d.ts
@@ -17,8 +17,6 @@ declare class Hyperschema {
 
   static esm: boolean
 
-  // Polymorphic `this` so subclasses get their own type back, matching the
-  // runtime's `new this(...)`: `SwiftHyperschema.from(null)` is a SwiftHyperschema.
   static from<T extends typeof Hyperschema>(
     this: T,
     json?: string | Hyperschema.SchemaJSON | null,

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "hyperschema",
   "version": "1.21.0",
   "description": "Create registries of declarative compact-encoding schemas",
+  "types": "./builder.d.ts",
   "files": [
     "lib/*.js",
     "builder.mjs",
     "builder.cjs",
+    "builder.d.ts",
     "runtime.mjs",
     "runtime.cjs",
     "primitives.mjs",
@@ -14,6 +16,7 @@
   "exports": {
     "./package": "./package.json",
     ".": {
+      "types": "./builder.d.ts",
       "import": "./builder.mjs",
       "default": "./builder.cjs"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "hyperschema",
   "version": "1.21.0",
   "description": "Create registries of declarative compact-encoding schemas",
-  "types": "./builder.d.ts",
   "files": [
     "lib/*.js",
     "builder.mjs",


### PR DESCRIPTION
Types the main (`.`) export so consumers — and subclasses like [hyperschema-swift](https://github.com/holepunchto/hyperschema-swift/pull/25) — can inherit typings instead of hand-redeclaring `namespace()`, `register()`, `toJSON()`, `version`, etc.

- `static from` uses a polymorphic `this`, so a subclass's `from()` returns the subclass (matching the runtime `new this(...)`). `SwiftHyperschema.from(null)` is a `SwiftHyperschema`.
- Wired via the top-level `types` field (classic resolution) and a `types` condition on the `.` export (node16/nodenext); added to `files` so it ships.
- Scoped to the builder; `./runtime` and `./primitives` can follow.

## Verification

No TS toolchain in the repo, so verified by installing the packed package into a scratch project and running `tsc --strict --noEmit`:

- A consumer mirroring the hyperschema-swift subclass typechecks under both `nodenext` and classic `node` resolution — `from(null)` returns the subclass, `namespace().register({...})`, `toJSON()`, `toCode()`, `toDisk()` all resolve.
- A negative test confirms the types arent vacuously `any`: missing `name`, `version` as `string`, and `namespace(123)` are all correctly rejected.
- Existing suite green (23/23), prettier clean.