### PR TITLE
Fix reload crash when a versioned type gains a version in a later generation

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -345,15 +345,14 @@ class VersionedType extends ResolvedType {
 
     this.versions = description.versions.map((v) => {
       return {
-        type: hyperschema.resolve(v.type),
+        typeName: v.type,
+        get type() {
+          return hyperschema.resolve(this.typeName)
+        },
         version: v.version,
         map: v.map || null
       }
     })
-
-    for (const v of this.versions) {
-      v.type.expectsVersion = true
-    }
 
     this.framed = true
 
@@ -372,6 +371,15 @@ class VersionedType extends ResolvedType {
     }
   }
 
+  link() {
+    for (const v of this.versions) {
+      if (!v.type) {
+        throw new Error(`VersionedType ${this.fqn}: cannot resolve version type ${v.typeName}`)
+      }
+      v.type.expectsVersion = true
+    }
+  }
+
   require(filename) {
     return p.relative(p.join(filename, '..'), p.resolve(this.filename)).replaceAll('\\', '/')
   }
@@ -381,7 +389,7 @@ class VersionedType extends ResolvedType {
       name: this.name,
       namespace: this.namespace,
       versions: this.versions.map((version) => ({
-        type: version.type.fqn,
+        type: version.typeName,
         map: version.map,
         version: version.version
       }))

--- a/test/basic.js
+++ b/test/basic.js
@@ -930,6 +930,71 @@ test('versioned struct', async (t) => {
   }
 })
 
+test('versioned struct gains a version in a later generation', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'thing-v1',
+      fields: [
+        {
+          name: 'value',
+          type: 'string',
+          required: true
+        }
+      ]
+    })
+
+    ns.register({
+      name: 'thing',
+      versions: [
+        {
+          version: 1,
+          type: '@test/thing-v1'
+        }
+      ]
+    })
+  })
+
+  // the v2 struct appends after the wrapper in the lineage - reload must tolerate the forward ref
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'thing-v2',
+      fields: [
+        {
+          name: 'value',
+          type: 'uint',
+          required: true
+        }
+      ]
+    })
+
+    ns.register({
+      name: 'thing',
+      versions: [
+        {
+          version: 1,
+          type: '@test/thing-v1'
+        },
+        {
+          version: 2,
+          type: '@test/thing-v2'
+        }
+      ]
+    })
+  })
+
+  await schema.rebuild(() => {})
+
+  const enc = schema.module.resolveStruct('@test/thing')
+  t.alike(c.decode(enc, c.encode(enc, { version: 1, value: '10' })), { version: 1, value: '10' })
+  t.alike(c.decode(enc, c.encode(enc, { version: 2, value: 10 })), { version: 2, value: 10 })
+})
+
 test('alias, enum, field versions should not sync with schema version if no change in definition', async (t) => {
   const schema = await createTestSchema(t)
 


### PR DESCRIPTION
schema.json is append-only, so a version struct added in a later generation lands after the wrapper that references it. Reloading then crashes:

```
TypeError: Cannot set properties of undefined (setting 'expectsVersion')
```

because VersionedType resolves its members eagerly, mid-load. This means no versioned type can ever gain a version after it has shipped.

The fix resolves members lazily and validates them in `link()`, the same way struct fields handle forward references. A genuinely missing type now fails at link time with an error naming it.

No format change: `toJSON` writes the same member names it always did.

The added test is the repro: register a versioned type, rebuild adding a v2, rebuild once more - the last reload crashes without the fix.

---
Part of a series making versioned types usable end-to-end: holepunchto/hyperschema#58 (reload fix), holepunchto/hyperschema#59 (maps persistence), holepunchto/hyperschema#60 (encode default), holepunchto/hyperdb#103 (versioned collection schemas), holepunchto/hyperschema-ts#9 (emitted types). Each stands alone except hyperdb#103, which needs #58 + #59.