### PR TITLE
Persist namespace externals in schema.json

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -576,6 +576,7 @@ class HyperschemaNamespace {
     this.hyperschema = hyperschema
     this.name = name
     this.external = null
+    this.fromJSON = false
   }
 
   require(filename) {
@@ -606,6 +607,15 @@ module.exports = class Hyperschema {
     this.initializing = true
 
     if (json) {
+      if (json.namespaces) {
+        for (const desc of json.namespaces) {
+          const ns = this.namespace(desc.name)
+          if (desc.external) {
+            ns.require(this.dir ? p.resolve(this.dir, desc.external) : desc.external)
+          }
+          ns.fromJSON = true
+        }
+      }
       for (let i = 0; i < json.schema.length; i++) {
         const description = json.schema[i]
         this.register(description)
@@ -669,7 +679,12 @@ module.exports = class Hyperschema {
   }
 
   namespace(name) {
-    if (this.namespaces.has(name)) throw new Error('Namespace already exists')
+    const existing = this.namespaces.get(name)
+    if (existing) {
+      if (!existing.fromJSON) throw new Error('Namespace already exists')
+      existing.fromJSON = false
+      return existing
+    }
     const ns = new HyperschemaNamespace(this, name)
     this.namespaces.set(name, ns)
     return ns
@@ -682,13 +697,23 @@ module.exports = class Hyperschema {
     return type
   }
 
-  toJSON() {
+  toJSON({ dir = this.dir } = {}) {
     this.linkAll()
 
     const json = {
       version: this.version,
       schema: this.schema.filter((t) => !t.derived)
     }
+    const namespaces = []
+    for (const ns of this.namespaces.values()) {
+      if (!ns.external) continue
+      const external = p.resolve(ns.external)
+      namespaces.push({
+        name: ns.name,
+        external: dir ? p.relative(p.resolve(dir), external).replaceAll('\\', '/') : external
+      })
+    }
+    if (namespaces.length > 0) json.namespaces = namespaces
     return json
   }
 
@@ -712,7 +737,7 @@ module.exports = class Hyperschema {
     const jsonPath = p.join(p.resolve(dir), JSON_FILE_NAME)
     const codePath = p.join(p.resolve(dir), CODE_FILE_NAME)
 
-    fs.writeFileSync(jsonPath, JSON.stringify(hyperschema.toJSON(), null, 2) + '\n', {
+    fs.writeFileSync(jsonPath, JSON.stringify(hyperschema.toJSON({ dir }), null, 2) + '\n', {
       encoding: 'utf-8'
     })
     fs.writeFileSync(codePath, hyperschema.toCode({ ...opts, filename: codePath }), {

--- a/builder.d.ts
+++ b/builder.d.ts
@@ -10,7 +10,7 @@ declare class Hyperschema {
   register(description: Hyperschema.TypeDescription): Hyperschema.ResolvedType
   namespace(name: string): Hyperschema.Namespace
   resolve(fqn: string, opts?: { aliases?: boolean }): Hyperschema.ResolvedType
-  toJSON(): Hyperschema.SchemaJSON
+  toJSON(opts?: { dir?: string | null }): Hyperschema.SchemaJSON
   toCode(opts?: Hyperschema.ToCodeOptions): string
   linkAll(): void
   maybeBumpVersion(): void
@@ -49,6 +49,7 @@ declare namespace Hyperschema {
   export interface SchemaJSON {
     version: number
     schema: object[]
+    namespaces?: { name: string; external: string }[]
   }
 
   export interface Namespace {

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,7 @@ const test = require('brittle')
 const c = require('compact-encoding')
 const path = require('path')
 
+const Hyperschema = require('../builder.cjs')
 const { createTestSchema } = require('./helpers')
 
 test('basic struct, all required fields, version bump', async (t) => {
@@ -1050,6 +1051,94 @@ test('versioned struct encodes the latest version by default', async (t) => {
     label: null
   })
   t.alike(c.decode(enc, c.encode(enc, { version: 1, value: 10 })), { version: 1, value: 10 })
+})
+
+test('versioned struct with a map survives a reload', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.require(path.join(__dirname, 'helpers/external.js'))
+
+    ns.register({
+      name: 'v0',
+      fields: [
+        {
+          name: 'value',
+          type: 'string',
+          required: true
+        }
+      ]
+    })
+
+    ns.register({
+      name: 'v1',
+      fields: [
+        {
+          name: 'value',
+          type: 'uint',
+          required: true
+        }
+      ]
+    })
+
+    ns.register({
+      name: 'versioned',
+      versions: [
+        {
+          version: 0,
+          type: '@test/v0',
+          map: 'map'
+        },
+        {
+          version: 1,
+          type: '@test/v1'
+        }
+      ]
+    })
+  })
+
+  t.alike(schema.json.namespaces, [
+    {
+      name: 'test',
+      external: path
+        .relative(schema.dir, path.join(__dirname, 'helpers/external.js'))
+        .replaceAll('\\', '/')
+    }
+  ])
+
+  // reload from disk only: the maps file must be remembered without a new require call
+  {
+    const schemaReload = Hyperschema.from(schema.dir)
+    t.execution(() => schemaReload.toCode({ filename: path.join(schema.dir, 'index-reloaded.js') }))
+  }
+
+  const schemaModuleLoaded = require(schema.dir)
+
+  const enc = schemaModuleLoaded.resolveStruct('@test/versioned')
+  t.alike(c.decode(enc, c.encode(enc, { version: 0, value: '10' })), { version: 0, value: 10 })
+})
+
+test('schema without externals persists no namespaces entry', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'plain',
+      fields: [
+        {
+          name: 'value',
+          type: 'uint',
+          required: true
+        }
+      ]
+    })
+  })
+
+  t.is(schema.json.namespaces, undefined)
 })
 
 test('alias, enum, field versions should not sync with schema version if no change in definition', async (t) => {


### PR DESCRIPTION
A maps file registered with `ns.require(path)` is only known to the build script that called it - the saved schema.json doesn't record it. Any tool that loads the schema from disk on its own (hyperdb's builder does) can't find the map functions, and codegen crashes on a null filename.

This writes each namespace's external into schema.json as a path relative to the schema dir, and restores it on load. `namespace(name)` hands a loaded namespace to its first caller instead of throwing; a second call still throws.

Back-compat:
- schemas without externals produce byte-identical schema.json - the key is only written when externals exist
- old readers ignore the new key (an old writer re-saving the file drops it, as with any new field)

`toJSON` takes an optional `dir` so `toDisk` anchors the relative path to the directory actually being written, which can differ from the one the schema was loaded from.

---
Part of a series making versioned types usable end-to-end: holepunchto/hyperschema#58 (reload fix), holepunchto/hyperschema#59 (maps persistence), holepunchto/hyperschema#60 (encode default), holepunchto/hyperdb#103 (versioned collection schemas), holepunchto/hyperschema-ts#9 (emitted types). Each stands alone except hyperdb#103, which needs #58 + #59.