### PR TITLE
Default an absent version to the latest on encode

### DIFF
--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -332,9 +332,11 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
     function generateEncode({ preencode = false } = {}) {
       const fn = preencode ? 'preencode' : 'encode'
+      const latest = struct.versions[struct.versions.length - 1].version
       let str = ''
-      str += `    c.uint.${fn}(state, m.version)\n`
-      str += '    switch (m.version) {\n'
+      str += `    const v = m.version ?? ${latest}\n`
+      str += `    c.uint.${fn}(state, v)\n`
+      str += '    switch (v) {\n'
       let version = 0
       for (let i = 0; i < struct.versions.length; i++) {
         const def = struct.versions[i]

--- a/test/basic.js
+++ b/test/basic.js
@@ -995,6 +995,63 @@ test('versioned struct gains a version in a later generation', async (t) => {
   t.alike(c.decode(enc, c.encode(enc, { version: 2, value: 10 })), { version: 2, value: 10 })
 })
 
+test('versioned struct encodes the latest version by default', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'v1',
+      fields: [
+        {
+          name: 'value',
+          type: 'uint',
+          required: true
+        }
+      ]
+    })
+
+    ns.register({
+      name: 'v2',
+      fields: [
+        {
+          name: 'value',
+          type: 'uint',
+          required: true
+        },
+        {
+          name: 'label',
+          type: 'string'
+        }
+      ]
+    })
+
+    ns.register({
+      name: 'versioned',
+      versions: [
+        {
+          version: 1,
+          type: '@test/v1'
+        },
+        {
+          version: 2,
+          type: '@test/v2'
+        }
+      ]
+    })
+  })
+
+  const enc = schema.module.resolveStruct('@test/versioned')
+
+  t.alike(c.decode(enc, c.encode(enc, { value: 10 })), {
+    version: 2,
+    value: 10,
+    label: null
+  })
+  t.alike(c.decode(enc, c.encode(enc, { version: 1, value: 10 })), { version: 1, value: 10 })
+})
+
 test('alias, enum, field versions should not sync with schema version if no change in definition', async (t) => {
   const schema = await createTestSchema(t)
 


### PR DESCRIPTION
Encoding a versioned struct requires `m.version`; an absent one hits the `default` branch and throws `Unsupported version`. So every write site must hand-stamp the latest version, and one missed stamp is a runtime crash.

New data is always the latest shape, so encode now defaults an absent version to it (baked in per type at codegen time). An explicit version still wins, and decode is unchanged - old bytes dispatch on the version they carry.

---
Part of a series making versioned types usable end-to-end: holepunchto/hyperschema#58 (reload fix), holepunchto/hyperschema#59 (maps persistence), holepunchto/hyperschema#60 (encode default), holepunchto/hyperdb#103 (versioned collection schemas), holepunchto/hyperschema-ts#9 (emitted types). Each stands alone except hyperdb#103, which needs #58 + #59.