### PR TITLE
test: conformance over hyperschema-test fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "brittle": "^3.7.0",
+    "hyperschema-test": "^1.1.0",
     "prettier": "^3.6.2",
     "prettier-config-holepunch": "^2.0.0",
     "test-tmp": "^1.3.0"

--- a/test/conformance.js
+++ b/test/conformance.js
@@ -44,8 +44,9 @@ for (const name of names) {
 
 function fixtures() {
   return fs
-    .readdirSync(fixturesDir)
-    .filter((name) => fs.statSync(p.join(fixturesDir, name)).isDirectory())
+    .readdirSync(fixturesDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name)
     .sort((a, b) => Number(a) - Number(b))
 }
 

--- a/test/conformance.js
+++ b/test/conformance.js
@@ -1,0 +1,65 @@
+const test = require('brittle')
+const c = require('compact-encoding')
+const fs = require('fs')
+const p = require('path')
+
+const Hyperschema = require('../builder.cjs')
+const { makeDir } = require('./helpers')
+
+const fixturesDir = p.join(p.dirname(require.resolve('hyperschema-test/package')), 'fixtures')
+
+const names = fixtures()
+
+// Without this, a fixtures dir that ships empty or restructured makes the whole
+// conformance suite pass by generating no tests at all
+test('fixtures are installed', (t) => {
+  t.ok(names.length > 0, 'hyperschema-test ships fixtures')
+})
+
+for (const name of names) {
+  test(`conformance, fixture ${name}`, async (t) => {
+    const fixtureDir = p.join(fixturesDir, name)
+    const json = JSON.parse(fs.readFileSync(p.join(fixtureDir, 'schema.json')))
+    const { values, encoded } = JSON.parse(fs.readFileSync(p.join(fixtureDir, 'test.json')))
+
+    const dir = await makeDir(t)
+    Hyperschema.toDisk(Hyperschema.from(fixtureDir), dir)
+
+    // Fixtures encode the last type registered in the schema
+    const target = json.schema[json.schema.length - 1]
+    const enc = require(dir).resolveStruct('@' + target.namespace + '/' + target.name)
+
+    for (let i = 0; i < values.length; i++) {
+      const expected = hex(encoded[i])
+
+      t.is(c.encode(enc, revive(values[i])).toString('hex'), expected, `encode ${i}`)
+
+      // Decoding is only asserted through re-encoding: the builder encodes falsy
+      // optionals as absent, so a decoded value need not match the input value
+      const decoded = c.decode(enc, Buffer.from(expected, 'hex'))
+      t.is(c.encode(enc, decoded).toString('hex'), expected, `decode ${i}`)
+    }
+  })
+}
+
+function fixtures() {
+  return fs
+    .readdirSync(fixturesDir)
+    .filter((name) => fs.statSync(p.join(fixturesDir, name)).isDirectory())
+    .sort((a, b) => Number(a) - Number(b))
+}
+
+function hex(encoded) {
+  return typeof encoded === 'string' ? encoded : Buffer.from(encoded.data).toString('hex')
+}
+
+// JSON round trips buffers as { type: 'Buffer', data: [...] }
+function revive(value) {
+  if (Array.isArray(value)) return value.map(revive)
+  if (value === null || typeof value !== 'object') return value
+  if (value.type === 'Buffer' && Array.isArray(value.data)) return Buffer.from(value.data)
+
+  const result = {}
+  for (const key of Object.keys(value)) result[key] = revive(value[key])
+  return result
+}

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -49,5 +49,6 @@ async function createTestSchema(t) {
 }
 
 module.exports = {
-  createTestSchema
+  createTestSchema,
+  makeDir
 }

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ async function runTests() {
   test.pause()
 
   await import('./basic.js')
+  await import('./conformance.js')
 
   test.resume()
 }


### PR DESCRIPTION
Runs the JS builder against the same cross-implementation fixtures that hyperschema-c, -python and -swift verify against: build each fixture's `schema.json`, encode its values, compare to the committed hex.

Decode is asserted by re-encoding rather than comparing to the input value, since the builder encodes falsy optionals as absent.

Covers the latest version of each schema only. 1.1.0 also ships `versioned` vectors for fixtures 2 and 19 (the same schema encoded at v1/v2/v3) - reading those is a follow-up, not covered here.