### PR TITLE
verify the versioned fixture vectors

### DIFF
--- a/test/conformance.js
+++ b/test/conformance.js
@@ -16,30 +16,66 @@ test('fixtures are installed', (t) => {
   t.ok(names.length > 0, 'hyperschema-test ships fixtures')
 })
 
+// Same reasoning: version-aware encoding is only covered while some fixture
+// actually carries older versions of its schema
+test('fixtures cover older schema versions', (t) => {
+  t.ok(
+    names.some((name) => readTest(name).versioned),
+    'a fixture ships versioned encodings'
+  )
+})
+
 for (const name of names) {
   test(`conformance, fixture ${name}`, async (t) => {
     const fixtureDir = p.join(fixturesDir, name)
     const json = JSON.parse(fs.readFileSync(p.join(fixtureDir, 'schema.json')))
-    const { values, encoded } = JSON.parse(fs.readFileSync(p.join(fixtureDir, 'test.json')))
+    const { values, encoded, versioned } = readTest(name)
 
     const dir = await makeDir(t)
     Hyperschema.toDisk(Hyperschema.from(fixtureDir), dir)
 
     // Fixtures encode the last type registered in the schema
     const target = json.schema[json.schema.length - 1]
-    const enc = require(dir).resolveStruct('@' + target.namespace + '/' + target.name)
+    const name_ = '@' + target.namespace + '/' + target.name
+    const module = require(dir)
 
-    for (let i = 0; i < values.length; i++) {
-      const expected = hex(encoded[i])
+    check(t, module.resolveStruct(name_), values, encoded, 'latest')
 
-      t.is(c.encode(enc, revive(values[i])).toString('hex'), expected, `encode ${i}`)
+    // Older versions of the same schema, oldest first, where the fixture has them
+    for (const older of versioned || []) {
+      const enc = module.resolveStruct(name_, older.version)
+      const label = 'v' + older.version
 
-      // Decoding is only asserted through re-encoding: the builder encodes falsy
-      // optionals as absent, so a decoded value need not match the input value
-      const decoded = c.decode(enc, Buffer.from(expected, 'hex'))
-      t.is(c.encode(enc, decoded).toString('hex'), expected, `decode ${i}`)
+      check(t, enc, older.values, older.encoded, label)
+
+      // The stored values are already projected onto that version, so the above
+      // passes even if the version is ignored. Encoding the latest values with
+      // the older encoder is what proves fields above it are dropped.
+      for (let i = 0; i < values.length; i++) {
+        const expected = hex(older.encoded[i])
+        const actual = c.encode(enc, revive(values[i])).toString('hex')
+
+        t.is(actual, expected, `${label} truncates case ${i}`)
+      }
     }
   })
+}
+
+function check(t, enc, values, encoded, label) {
+  for (let i = 0; i < values.length; i++) {
+    const expected = hex(encoded[i])
+
+    t.is(c.encode(enc, revive(values[i])).toString('hex'), expected, `${label} encode ${i}`)
+
+    // Decoding is only asserted through re-encoding: the builder encodes falsy
+    // optionals as absent, so a decoded value need not match the input value
+    const decoded = c.decode(enc, Buffer.from(expected, 'hex'))
+    t.is(c.encode(enc, decoded).toString('hex'), expected, `${label} decode ${i}`)
+  }
+}
+
+function readTest(name) {
+  return JSON.parse(fs.readFileSync(p.join(fixturesDir, name, 'test.json')))
 }
 
 function fixtures() {


### PR DESCRIPTION
hyperschema-test 1.1.0 ships v1/v2/v3 encodings for fixtures 2 and 19 that no implementation read - the gap #64 left open.

The catch is that the per-version entries store values *already projected onto that version* (`email: null`), so encoding them at the latest version yields identical bytes: an absent optional is absent either way. Asserting only those passes even when version dispatch is entirely broken - I checked by forcing `v = VERSION` inside the generated `getStruct`, and all 44 tests stayed green.

So it also encodes the **latest** values with the **older** encoder, which must drop fields above that version. With that in, the same sabotage fails on exactly the cases carrying a v2-only field (`v1 truncates case 0/2/3/5/7/8`), while the genuinely insensitive cases stay green.

44 tests / 848 asserts in conformance, 30 of them the truncation checks; full suite 71 tests / 938 asserts on node and bare. Also guards that some fixture still ships versioned entries, so this cannot silently become a no-op.