### PR TITLE
fix: length-frame embedded versioned structs so an older reader stays aligned

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -385,6 +385,10 @@ class VersionedType extends ResolvedType {
     }
   }
 
+  frameable() {
+    return this.framed
+  }
+
   require(filename) {
     return p.relative(p.join(filename, '..'), p.resolve(this.filename)).replaceAll('\\', '/')
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -1563,3 +1563,151 @@ test('array of bools - bitwise uints cannot be arrays', async (t) => {
     /cannot be used as an array/
   )
 })
+
+test('embedded versioned struct stays aligned when a later generation appends an optional field', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const tail = Buffer.alloc(32, 7)
+  const value = {
+    inner: { version: 1, count: 1, label: 'a', extra: 'b'.repeat(64) },
+    tail
+  }
+
+  const encoded = c.encode(gen2.resolveStruct('@test/outer'), value)
+  const decoded = c.decode(gen1.resolveStruct('@test/outer'), encoded)
+
+  t.alike(decoded.inner, { version: 1, count: 1, label: 'a' })
+  t.alike(decoded.tail, tail)
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' },
+        ...(extra ? [{ name: 'extra', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
+test('embedded versioned struct stays aligned when a later generation adds its first optional field', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const tail = Buffer.alloc(32, 9)
+
+  // the new field is never set, but the flags byte it introduces still shifts an unframed embed
+  const encoded = c.encode(gen2.resolveStruct('@test/outer'), {
+    inner: { version: 1, count: 3 },
+    tail
+  })
+  const decoded = c.decode(gen1.resolveStruct('@test/outer'), encoded)
+
+  t.alike(decoded.inner, { version: 1, count: 3 })
+  t.alike(decoded.tail, tail)
+
+  function define(schema, optional) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        ...(optional ? [{ name: 'label', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
+test('embedded versioned struct round trips within and across generations', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const enc1 = gen1.resolveStruct('@test/outer')
+  const enc2 = gen2.resolveStruct('@test/outer')
+  const tail = Buffer.alloc(32, 4)
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a', extra: 'e' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc2, value)), value)
+  }
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc1, value)), {
+      inner: { version: 1, count: 7, label: 'a', extra: null },
+      tail
+    })
+  }
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' },
+        ...(extra ? [{ name: 'extra', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})


### PR DESCRIPTION
Every embedded non-compact struct is length-framed today: `StructField.framed` delegates to `type.frameable()`, `Struct.frameable()` returns `!this.compact`, `Alias` delegates, and `getGeneratedFieldEncoder` emits `c.frame(...)` from there.

`VersionedType` sets `this.framed = true` in its constructor, mirroring `Array.framed`, but never overrides `frameable()`. So it inherits `ResolvedType.frameable()` returning `false`, and that flag is dead state that nothing reads. Versioned types are the one embedded kind that is not framed.

Without the frame, a reader that predates an optional field appended inside the embedded struct skips the flag without consuming the bytes that field wrote, so every field after the embed decodes from the wrong offset. Nothing throws:

```
outer { inner: { count, label, extra }, tail: fixed32 }

gen-2 writes: inner.extra = 'b'.repeat(64), tail = <32 bytes of 0x07>
gen-1 reads:  tail = [100, 98, 98, 98, ...]   <- 0x40 length byte, then the 'b' payload
```

A struct gaining its *first* optional field shifts unconditionally, even when the field is never set, because the flags byte itself is new.

The fix is the missing override. `c.frame` clamps `state.end` to the frame, decodes, then sets `state.start = state.end`, so the cursor lands past the frame whatever the inner decoder understood.

This does change bytes for anyone already embedding a versioned type, so it wants a major bump. `toJSON` is untouched, so no existing `schema.json` changes.

Three tests: an appended optional field stays aligned, a first optional field stays aligned while unset, and a round-trip guard within and across generations. The first two fail without the change, and the failure is the corruption above.

Worth flagging for the release note: no conformance fixture embeds a versioned type today (26 uses one, top-level), so no vectors shift. One added later would need regenerating.

If you would rather not break existing consumers, I have a follow-up branch adding `framed: false` on the type declaration to keep the old layout, persisted into `schema.json` only when set. Happy to fold it in or send it separately.
