### PR TITLE
fix: length-frame new versioned structs, keep existing schemas on their layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ All struct definitions must take the following form:
 - `name`: (required) The name of the alias.
 - `type`: (required) Either a built-in type (i.e. `uint`) or a fully-qualified user-defined type (i.e. `@namespace/another-struct`)
 
+#### Versioned Type Definition
+
+- `name`: (required) The name of the versioned type.
+- `versions`: (required) An array of `{ version, type, map }`, where `type` is the struct encoding that version and `map` optionally names an exported function that projects it onto the newest shape.
+- `framed`: (optional) When embedded in another struct, length-prefix the encoding so a reader that does not understand a newer inner version still finds the fields after it. New types default to `true`. A type loaded from a `schema.json` written before framing existed keeps its unframed layout; set `framed: true` on it to migrate, which changes the bytes it writes.
+
 ### API
 
 Hyperschema lets you define structs and aliases. All [`compact-encoding`](https://github.com/holepunchto/compact-encoding) types are available as built-in types.

--- a/builder.cjs
+++ b/builder.cjs
@@ -354,7 +354,8 @@ class VersionedType extends ResolvedType {
       }
     })
 
-    this.framed = true
+    // a schema.json written before framing existed has no flag: keep its layout
+    this.framed = description.framed ?? existing?.framed ?? !hyperschema.initializing
 
     if (!description.name) {
       throw new Error(`VersionedType ${this.fqn}: required 'name' definition is missing`)
@@ -392,6 +393,7 @@ class VersionedType extends ResolvedType {
     return {
       name: this.name,
       namespace: this.namespace,
+      framed: this.framed,
       versions: this.versions.map((version) => ({
         type: version.typeName,
         map: version.map,

--- a/builder.cjs
+++ b/builder.cjs
@@ -380,6 +380,10 @@ class VersionedType extends ResolvedType {
     }
   }
 
+  frameable() {
+    return this.framed
+  }
+
   require(filename) {
     return p.relative(p.join(filename, '..'), p.resolve(this.filename)).replaceAll('\\', '/')
   }

--- a/test/basic.js
+++ b/test/basic.js
@@ -1281,3 +1281,151 @@ test('basic default', async (t) => {
     t.alike(dec, { foo: 1, bar: null, baz: undefined, far: Buffer.alloc(3, 3) })
   }
 })
+
+test('embedded versioned struct stays aligned when a later generation appends an optional field', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const tail = Buffer.alloc(32, 7)
+  const value = {
+    inner: { version: 1, count: 1, label: 'a', extra: 'b'.repeat(64) },
+    tail
+  }
+
+  const encoded = c.encode(gen2.resolveStruct('@test/outer'), value)
+  const decoded = c.decode(gen1.resolveStruct('@test/outer'), encoded)
+
+  t.alike(decoded.inner, { version: 1, count: 1, label: 'a' })
+  t.alike(decoded.tail, tail)
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' },
+        ...(extra ? [{ name: 'extra', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
+test('embedded versioned struct stays aligned when a later generation adds its first optional field', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const tail = Buffer.alloc(32, 9)
+
+  // the new field is never set, but the flags byte it introduces still shifts an unframed embed
+  const encoded = c.encode(gen2.resolveStruct('@test/outer'), {
+    inner: { version: 1, count: 3 },
+    tail
+  })
+  const decoded = c.decode(gen1.resolveStruct('@test/outer'), encoded)
+
+  t.alike(decoded.inner, { version: 1, count: 3 })
+  t.alike(decoded.tail, tail)
+
+  function define(schema, optional) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        ...(optional ? [{ name: 'label', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
+test('embedded versioned struct round trips within and across generations', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const enc1 = gen1.resolveStruct('@test/outer')
+  const enc2 = gen2.resolveStruct('@test/outer')
+  const tail = Buffer.alloc(32, 4)
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a', extra: 'e' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc2, value)), value)
+  }
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc1, value)), {
+      inner: { version: 1, count: 7, label: 'a', extra: null },
+      tail
+    })
+  }
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' },
+        ...(extra ? [{ name: 'extra', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const c = require('compact-encoding')
+const fs = require('fs')
 const path = require('path')
 
 const Hyperschema = require('../builder.cjs')
@@ -1429,3 +1430,81 @@ test('embedded versioned struct round trips within and across generations', asyn
     })
   }
 })
+
+test('a newly declared versioned type is framed and records it', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(define)
+
+  t.is(schema.json.schema[1].framed, true)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 1 + 2 + 32)
+
+  // the flag survives a reload
+  await schema.rebuild(define)
+  t.is(schema.json.schema[1].framed, true)
+})
+
+test('a schema written before framing keeps its layout', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(define)
+  dropFramed(schema.dir)
+
+  await schema.rebuild(define)
+
+  t.is(schema.json.schema[1].framed, false)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 2 + 32)
+
+  // and stays grandfathered on every later build
+  await schema.rebuild(define)
+  t.is(schema.json.schema[1].framed, false)
+})
+
+test('a grandfathered versioned type can opt in to framing', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(define)
+  dropFramed(schema.dir)
+
+  await schema.rebuild((schema) => define(schema, true))
+
+  t.is(schema.json.schema[1].framed, true)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 1 + 2 + 32)
+})
+
+function dropFramed(dir) {
+  const file = path.join(dir, 'schema.json')
+  const json = JSON.parse(fs.readFileSync(file, 'utf-8'))
+  for (const type of json.schema) delete type.framed
+  fs.writeFileSync(file, JSON.stringify(json, null, 2))
+}
+
+function encodeOuter(module) {
+  return c.encode(module.resolveStruct('@test/outer'), {
+    inner: { version: 1, count: 3 },
+    tail: Buffer.alloc(32, 1)
+  })
+}
+
+function define(schema, framed) {
+  const ns = schema.namespace('test')
+
+  ns.register({
+    name: 'inner-v1',
+    fields: [{ name: 'count', type: 'uint', required: true }]
+  })
+
+  ns.register({
+    name: 'inner',
+    ...(framed ? { framed } : {}),
+    versions: [{ version: 1, type: '@test/inner-v1' }]
+  })
+
+  ns.register({
+    name: 'outer',
+    fields: [
+      { name: 'inner', type: '@test/inner' },
+      { name: 'tail', type: 'fixed32', required: true }
+    ]
+  })
+}


### PR DESCRIPTION
Same fix as #66, applied only going forward. A versioned type read back from a `schema.json` with no `framed` flag predates framing, so it keeps its unframed layout. New types are framed, and `framed: true` migrates an old one.

No major bump. Existing schemas only gain `"framed": false` on their next build.

The first commit is #66.