### PR TITLE
Framed versioned structs framed at version

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ All struct definitions must take the following form:
 - `name`: (required) The name of the alias.
 - `type`: (required) Either a built-in type (i.e. `uint`) or a fully-qualified user-defined type (i.e. `@namespace/another-struct`)
 
+#### Versioned Type Definition
+
+- `name`: (required) The name of the versioned type.
+- `versions`: (required) An array of `{ version, type, map }`, where `type` is the struct encoding that version and `map` optionally names an exported function that projects it onto the newest shape.
+- `framed`: (optional) When embedded in another struct, length-prefix the encoding so a reader that does not understand a newer inner version still finds the fields after it. New types default to `true`. A type loaded from a `schema.json` written before framing existed keeps its unframed layout; set `framed: true` on it to migrate, which changes the bytes it writes.
+
 ### API
 
 Hyperschema lets you define structs and aliases. All [`compact-encoding`](https://github.com/holepunchto/compact-encoding) types are available as built-in types.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ All struct definitions must take the following form:
 
 - `name`: (required) The name of the versioned type.
 - `versions`: (required) An array of `{ version, type, map }`, where `type` is the struct encoding that version and `map` optionally names an exported function that projects it onto the newest shape.
-- `framed`: (optional) When embedded in another struct, length-prefix the encoding so a reader that does not understand a newer inner version still finds the fields after it. New types default to `true`. A type loaded from a `schema.json` written before framing existed keeps its unframed layout; set `framed: true` on it to migrate, which changes the bytes it writes.
+- `framed`: (optional) When embedded in another struct, length-prefix the encoding for the inner version struct if it is not compact. New types default to `true`. A type loaded from a `schema.json` written before framing existed keeps its unframed layout; set `framed: true` on it to migrate, which changes the bytes it writes.
 
 ### API
 

--- a/builder.cjs
+++ b/builder.cjs
@@ -377,12 +377,7 @@ class VersionedType extends ResolvedType {
       if (!v.type) {
         throw new Error(`VersionedType ${this.fqn}: cannot resolve version type ${v.typeName}`)
       }
-      v.type.expectsVersion = true
     }
-  }
-
-  frameable() {
-    return this.framed
   }
 
   require(filename) {
@@ -410,7 +405,6 @@ class Struct extends ResolvedType {
     this.isInlined = false
 
     this.default = null
-    this.expectsVersion = false
 
     this.fields = []
     this.fieldsByName = new Map()

--- a/builder.cjs
+++ b/builder.cjs
@@ -354,7 +354,8 @@ class VersionedType extends ResolvedType {
       }
     })
 
-    this.framed = true
+    // a schema.json written before framing existed has no flag: keep its layout
+    this.framed = description.framed ?? existing?.framed ?? !hyperschema.initializing
 
     if (!description.name) {
       throw new Error(`VersionedType ${this.fqn}: required 'name' definition is missing`)
@@ -392,6 +393,7 @@ class VersionedType extends ResolvedType {
     return {
       name: this.name,
       namespace: this.namespace,
+      framed: this.framed,
       versions: this.versions.map((version) => ({
         type: version.typeName,
         map: version.map,

--- a/builder.cjs
+++ b/builder.cjs
@@ -380,6 +380,10 @@ class VersionedType extends ResolvedType {
     }
   }
 
+  frameable() {
+    return this.framed
+  }
+
   require(filename) {
     return p.relative(p.join(filename, '..'), p.resolve(this.filename)).replaceAll('\\', '/')
   }

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -51,7 +51,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     result.encoder = struct.isEnum
       ? generateEnum(result.id, struct)
       : struct.isVersioned
-        ? generateVersioned(result.id, struct)
+        ? generateVersioned(result.id, struct, deferred)
         : generateStruct(result.id, struct, deferred, false)
 
     if (struct.isInlined) {
@@ -303,9 +303,34 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     return typeStr
   }
 
-  function generateVersioned(id, struct) {
+  function generateVersioned(id, struct, deferred) {
+    const framedVersions = new Map()
+
     let str = ''
     let enc = ''
+
+    // Generate framed versions of version structs
+    for (let i = 0; i < struct.versions.length; i++) {
+      const def = struct.versions[i]
+      if (!struct.framed || !def.type.frameable()) continue
+
+      const typeId = `${id}_${i}`
+      const fieldEnc = `c.frame(${getGeneratedTypeEncoder(def.type)})`
+      const isDeferred = !!dedup.get(fieldEnc)?.deferred
+
+      // if recursive, defer the framed version type
+      if (structsByName.get(def.type.fqn)?.encoder === null || isDeferred) {
+        let d = ''
+        d += `// ${struct.fqn} v${def.version}, deferred due to recusive use\n`
+        const line = dedupConst(typeId, fieldEnc, true)
+        d += line.replace(/\n$/, ' // framed version\n')
+        deferred.push(d)
+      } else {
+        const line = dedupConst(typeId, fieldEnc, false)
+        str += line.replace(/\n$/, ' // framed version\n')
+      }
+      framedVersions.set(def, typeId)
+    }
 
     str += `// ${struct.fqn}\n`
     str += ''
@@ -341,7 +366,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
       for (let i = 0; i < struct.versions.length; i++) {
         const def = struct.versions[i]
         while (version <= def.version) str += `      case ${version++}:\n`
-        str += `        ${getEncoder(def.type)}.${fn}(state, m)\n`
+        str += `        ${getEncoder(def)}.${fn}(state, m)\n`
         str += '        break\n'
       }
       str += '      default:\n'
@@ -353,16 +378,15 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
     function generateDecode() {
       let str = ''
-      str += '    const start = state.start\n'
       str += '    const v = c.uint.decode(state)\n'
-      str += '    state.start = start\n'
       str += '    switch (v) {'
       let version = 0
       for (let i = 0; i < struct.versions.length; i++) {
         const def = struct.versions[i]
         while (version <= def.version) str += `\n      case ${version++}:`
         str += ' {\n'
-        str += `        const decoded = ${getEncoder(def.type)}.decode(state)\n`
+        str += `        const decoded = ${getEncoder(def)}.decode(state)\n`
+        str += '        decoded.version = v\n'
         if (def.map) {
           const v = requireExternal(struct, filename)
           str += `        const map = ${gen(v, def.map)}\n`
@@ -379,10 +403,9 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
       return str
     }
 
-    function getEncoder(type) {
-      if (type.isAlias) return getEncoder(type.type)
-      if (type.isPrimitive) return getPrimitiveEncoder(type)
-      return structsByName.get(type.fqn).id
+    function getEncoder(def) {
+      if (framedVersions.has(def)) return framedVersions.get(def)
+      return getGeneratedTypeEncoder(def.type)
     }
   }
 
@@ -573,10 +596,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
       let str = ''
       let seen = 0
 
-      if (struct.expectsVersion) {
-        str += '    const v = c.uint.decode(state)\n'
-      }
-
       const pre = new Map()
       for (let i = 0; i < fields.length; i++) {
         const field = fields[i].field
@@ -602,7 +621,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
       }
 
       str += '    return {\n'
-      if (struct.expectsVersion) str += '      version: v,\n'
 
       for (let i = 0; i < fields.length; i++) {
         const f = fields[i]
@@ -706,13 +724,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
     function getFieldEncoder(field) {
       if (fieldTypes.has(field.name)) return fieldTypes.get(field.name)
-      return getEncoder(field.type)
-    }
-
-    function getEncoder(type) {
-      if (type.isAlias) return getEncoder(type.type)
-      if (type.isPrimitive) return getPrimitiveEncoder(type)
-      return structsByName.get(type.fqn).id
+      return getGeneratedTypeEncoder(field.type)
     }
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -1431,6 +1431,77 @@ test('embedded versioned struct round trips within and across generations', asyn
   }
 })
 
+test('dont frame compact version of versioned struct', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const enc1 = gen1.resolveStruct('@test/outer')
+  const enc2 = gen2.resolveStruct('@test/outer')
+  const tail = Buffer.alloc(32, 4)
+
+  {
+    const value = { inner: { version: 2, count: 7, label: 'a', extra: 'e' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc2, value)), value, 'roundtrip on recent')
+  }
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a' }, tail }
+    t.alike(
+      c.decode(enc2, c.encode(enc1, value)),
+      {
+        inner: { version: 1, count: 7, label: 'a' },
+        tail
+      },
+      'encode w/ 1 -> decode w/ 2'
+    )
+  }
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      compact: true,
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' }
+      ]
+    })
+
+    if (extra) {
+      ns.register({
+        name: 'inner-v2',
+        fields: [
+          { name: 'count', type: 'uint', required: true },
+          { name: 'label', type: 'string' },
+          { name: 'extra', type: 'string' }
+        ]
+      })
+    }
+
+    ns.register({
+      name: 'inner',
+      versions: [
+        { version: 1, type: '@test/inner-v1' },
+        ...(extra ? [{ version: 2, type: '@test/inner-v2' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
 test('a newly declared versioned type is framed and records it', async (t) => {
   const schema = await createTestSchema(t)
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1515,6 +1515,19 @@ test('a newly declared versioned type is framed and records it', async (t) => {
   t.is(schema.json.schema[1].framed, true)
 })
 
+test('a newly declared versioned type can disable framing and records it', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+
+  t.is(schema.json.schema[1].framed, false)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 2 + 32)
+
+  // the flag survives a reload
+  await schema.rebuild(define)
+  t.is(schema.json.schema[1].framed, false)
+})
+
 test('a schema written before framing keeps its layout', async (t) => {
   const schema = await createTestSchema(t)
 
@@ -1557,7 +1570,7 @@ function encodeOuter(module) {
   })
 }
 
-function define(schema, framed) {
+function define(schema, framed = null) {
   const ns = schema.namespace('test')
 
   ns.register({
@@ -1567,7 +1580,7 @@ function define(schema, framed) {
 
   ns.register({
     name: 'inner',
-    ...(framed ? { framed } : {}),
+    ...(framed == null ? {} : { framed }),
     versions: [{ version: 1, type: '@test/inner-v1' }]
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1281,3 +1281,151 @@ test('basic default', async (t) => {
     t.alike(dec, { foo: 1, bar: null, baz: undefined, far: Buffer.alloc(3, 3) })
   }
 })
+
+test('embedded versioned struct stays aligned when a later generation appends an optional field', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const tail = Buffer.alloc(32, 7)
+  const value = {
+    inner: { version: 1, count: 1, label: 'a', extra: 'b'.repeat(64) },
+    tail
+  }
+
+  const encoded = c.encode(gen2.resolveStruct('@test/outer'), value)
+  const decoded = c.decode(gen1.resolveStruct('@test/outer'), encoded)
+
+  t.alike(decoded.inner, { version: 1, count: 1, label: 'a' })
+  t.alike(decoded.tail, tail)
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' },
+        ...(extra ? [{ name: 'extra', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
+test('embedded versioned struct stays aligned when a later generation adds its first optional field', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const tail = Buffer.alloc(32, 9)
+
+  // the new field is never set, but the flags byte it introduces still shifts an unframed embed
+  const encoded = c.encode(gen2.resolveStruct('@test/outer'), {
+    inner: { version: 1, count: 3 },
+    tail
+  })
+  const decoded = c.decode(gen1.resolveStruct('@test/outer'), encoded)
+
+  t.alike(decoded.inner, { version: 1, count: 3 })
+  t.alike(decoded.tail, tail)
+
+  function define(schema, optional) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        ...(optional ? [{ name: 'label', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})
+
+test('embedded versioned struct round trips within and across generations', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => define(schema, false))
+  const gen1 = schema.module
+
+  await schema.rebuild((schema) => define(schema, true))
+  const gen2 = schema.module
+
+  const enc1 = gen1.resolveStruct('@test/outer')
+  const enc2 = gen2.resolveStruct('@test/outer')
+  const tail = Buffer.alloc(32, 4)
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a', extra: 'e' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc2, value)), value)
+  }
+
+  {
+    const value = { inner: { version: 1, count: 7, label: 'a' }, tail }
+    t.alike(c.decode(enc2, c.encode(enc1, value)), {
+      inner: { version: 1, count: 7, label: 'a', extra: null },
+      tail
+    })
+  }
+
+  function define(schema, extra) {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'inner-v1',
+      fields: [
+        { name: 'count', type: 'uint', required: true },
+        { name: 'label', type: 'string' },
+        ...(extra ? [{ name: 'extra', type: 'string' }] : [])
+      ]
+    })
+
+    ns.register({
+      name: 'inner',
+      versions: [{ version: 1, type: '@test/inner-v1' }]
+    })
+
+    ns.register({
+      name: 'outer',
+      fields: [
+        { name: 'inner', type: '@test/inner' },
+        { name: 'tail', type: 'fixed32', required: true }
+      ]
+    })
+  }
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const c = require('compact-encoding')
+const fs = require('fs')
 const path = require('path')
 
 const Hyperschema = require('../builder.cjs')
@@ -1429,3 +1430,81 @@ test('embedded versioned struct round trips within and across generations', asyn
     })
   }
 })
+
+test('a newly declared versioned type is framed and records it', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(define)
+
+  t.is(schema.json.schema[1].framed, true)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 1 + 2 + 32)
+
+  // the flag survives a reload
+  await schema.rebuild(define)
+  t.is(schema.json.schema[1].framed, true)
+})
+
+test('a schema written before framing keeps its layout', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(define)
+  dropFramed(schema.dir)
+
+  await schema.rebuild(define)
+
+  t.is(schema.json.schema[1].framed, false)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 2 + 32)
+
+  // and stays grandfathered on every later build
+  await schema.rebuild(define)
+  t.is(schema.json.schema[1].framed, false)
+})
+
+test('a grandfathered versioned type can opt in to framing', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild(define)
+  dropFramed(schema.dir)
+
+  await schema.rebuild((schema) => define(schema, true))
+
+  t.is(schema.json.schema[1].framed, true)
+  t.is(encodeOuter(schema.module).byteLength, 1 + 1 + 2 + 32)
+})
+
+function dropFramed(dir) {
+  const file = path.join(dir, 'schema.json')
+  const json = JSON.parse(fs.readFileSync(file, 'utf-8'))
+  for (const type of json.schema) delete type.framed
+  fs.writeFileSync(file, JSON.stringify(json, null, 2))
+}
+
+function encodeOuter(module) {
+  return c.encode(module.resolveStruct('@test/outer'), {
+    inner: { version: 1, count: 3 },
+    tail: Buffer.alloc(32, 1)
+  })
+}
+
+function define(schema, framed) {
+  const ns = schema.namespace('test')
+
+  ns.register({
+    name: 'inner-v1',
+    fields: [{ name: 'count', type: 'uint', required: true }]
+  })
+
+  ns.register({
+    name: 'inner',
+    ...(framed ? { framed } : {}),
+    versions: [{ version: 1, type: '@test/inner-v1' }]
+  })
+
+  ns.register({
+    name: 'outer',
+    fields: [
+      { name: 'inner', type: '@test/inner' },
+      { name: 'tail', type: 'fixed32', required: true }
+    ]
+  })
+}

--- a/test/basic.js
+++ b/test/basic.js
@@ -1741,6 +1741,13 @@ test('dont frame compact version of versioned struct', async (t) => {
       },
       'encode w/ 1 -> decode w/ 2'
     )
+
+    // Show /inner doesnt frame v1
+    const inner = gen2.resolveStruct('@test/inner')
+    const encoded = c.encode(inner, { version: 1, count: 7, label: 'a' })
+    // optional fields (label), so there is flags byte:
+    // 01 (version) 07 (count) 01 (flags) 01 61 (string)
+    t.is(encoded.toString('hex'), '0107010161', 'no frame length')
   }
 
   function define(schema, extra) {


### PR DESCRIPTION
Building off of @shavtvalishvili's work, this PR puts the framing on the nested struct / child struct of a versioned struct. This allows the child structs to be compact and skip framing.

For this two changes were made:

1. The double decoding of the version (added here: 54c0983bbd0751904e78a722d55580bd150ca065), once for the versioned struct and once for the selected version, is no longer supported. It no longer works because the version byte is read instead by the framed version of the version struct when its frameable. Instead the versioned struct decodes it once and sets the version on the inner struct.

2. Field encoder for normal structs now uses `getGeneratedTypeEncoder()` instead of checking the type alone (`isAlias`, `isPrimitive`) and delegating. This allows reuse of the virtually equivalent logic for both versioned structs and normal structs. It was noticed when generating the encoder for a framed version struct. The catch currently is that version struct types will not resolve framed versions of their type through an alias. This is acceptable at the moment because registering aliases as version struct type isn't supported.

From @shavtvalishvili work, this PR includes the grandfathering mechanism as otherwise this would be a breaking change. The grandfather mechanism will check the persisted JSON for whether the versioned struct has `framed` set. If it doesn't, then it defaults to `framed: false` and will be persisted next update. If a new versioned struct is added (aka wasn't existing) it will default to `framed: true`.

PR'ed with AI assistance.