### PR TITLE
Use compact encoding bitarray for arrays of booleans

### DIFF
--- a/builder.cjs
+++ b/builder.cjs
@@ -5,7 +5,8 @@ const {
   SupportedTypes,
   BitwiseNumericTypes,
   getBitwiseSize,
-  getDefaultValue
+  getDefaultValue,
+  getOptimizedEncoder
 } = require('./lib/types.js')
 
 const generateCode = require('./lib/codegen')
@@ -232,6 +233,7 @@ class StructField {
     if (this.type === null) {
       throw new Error(`Cannot resolve field type ${this.description.type} in ${this.name}`)
     }
+    this.optimizedEncoder = getOptimizedEncoder(this)
   }
 
   get framed() {
@@ -263,6 +265,7 @@ class Array extends ResolvedType {
 
     this.type = hyperschema.resolve(description.type)
     this.framed = this.type.frameable()
+    this.optimizedEncoder = getOptimizedEncoder(this)
 
     // a bitwise uint has no standalone encoding, it only exists inside a struct's flags
     if (BitwiseNumericTypes.has(description.type)) {

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -92,6 +92,8 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
   for (let i = 0; i < structs.length; i++) {
     const struct = structs[i]
     const { encoder } = structsByName.get(struct.fqn)
+    // Skip printing encoders optimized to compact-encoder types
+    if (encoder === '') continue
     str += encoder
     str += '\n'
   }

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -1,8 +1,6 @@
 const gen = require('generate-object-property')
 const s = require('generate-string')
-const { BitwiseNumericTypes, getBitwiseSize } = require('./types.js')
-
-const BOOL_ARRAY_ID = 'c.bitarray'
+const { BitwiseNumericTypes, getBitwiseSize, getOptimizedEncoder } = require('./types.js')
 
 module.exports = function generateSchema(hyperschema, { esm = false, filename } = {}) {
   const structs = []
@@ -283,10 +281,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
   }
 
   function getGeneratedFieldEncoder(field) {
-    if (field.array && isBoolType(field.type)) {
-      return BOOL_ARRAY_ID
-    }
-
     const typeStr = getGeneratedTypeEncoder(field.type)
 
     if (field.array) {
@@ -404,10 +398,15 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     let enc = ''
     let keyEnc = ''
 
-    const boolArray = struct.isArray && isBoolType(struct.type)
-
     if (struct.isArray) {
-      enc = boolArray ? BOOL_ARRAY_ID : getGeneratedTypeEncoder(struct.type)
+      const optimized = getOptimizedEncoder(struct)
+      if (optimized) {
+        // already an existing compact-encoding reference - point every usage
+        // of this type directly at it instead of generating a local alias
+        structsByName.get(struct.fqn).id = optimized
+        return ''
+      }
+      enc = getGeneratedTypeEncoder(struct.type)
     } else if (struct.isRecord) {
       keyEnc = getGeneratedTypeEncoder(struct.key)
       enc = getGeneratedTypeEncoder(struct.value)
@@ -415,6 +414,15 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
       for (let i = 0; i < struct.fields.length; i++) {
         const field = struct.fields[i]
         if (!field.framed && !field.array) continue
+
+        const optimized = getOptimizedEncoder(field)
+
+        // already an existing compact-encoding reference - use it directly
+        // rather than generating a local alias for it
+        if (optimized) {
+          fieldTypes.set(field.name, optimized)
+          continue
+        }
 
         const fieldId = `${id}_${i}`
         fieldTypes.set(field.name, fieldId)
@@ -458,9 +466,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     str += `// ${struct.fqn}${inlinable ? ' (inline)' : ''}\n`
 
     if (struct.isArray) {
-      if (boolArray) {
-        str += dedupConst(id, enc)
-      } else if (struct.framed) {
+      if (struct.framed) {
         str += dedupConst(id, `c.array(c.frame(${enc}))`)
       } else {
         str += dedupConst(id, `c.array(${enc})`)
@@ -732,11 +738,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 function isFlagField(field) {
   if (field.array) return false
   return !!(field.type.bool || field.type.bitwise)
-}
-
-function isBoolType(type) {
-  if (type.isAlias) return isBoolType(type.type)
-  return !!type.bool
 }
 
 function alwaysOptional(struct) {

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -2,41 +2,7 @@ const gen = require('generate-object-property')
 const s = require('generate-string')
 const { BitwiseNumericTypes, getBitwiseSize } = require('./types.js')
 
-const BOOL_ARRAY_ID = 'boolArray'
-
-// An array of bools is packed into a bitfield: a uint length prefix followed by
-// ceil(length / 8) bytes, least significant bit first. Every byte is assigned
-// rather than or'd in, since the encoding buffer is not zero filled.
-const BOOL_ARRAY_ENCODER = `// array of bools, packed as a bitfield
-const ${BOOL_ARRAY_ID} = {
-  preencode(state, m) {
-    c.uint.preencode(state, m.length)
-    state.end += Math.ceil(m.length / 8)
-  },
-  encode(state, m) {
-    c.uint.encode(state, m.length)
-    for (let i = 0; i < m.length; i += 8) {
-      let byte = 0
-      for (let j = 0; j < 8 && i + j < m.length; j++) {
-        if (m[i + j]) byte |= 1 << j
-      }
-      state.buffer[state.start++] = byte
-    }
-  },
-  decode(state) {
-    const n = c.uint.decode(state)
-    if (state.end - state.start < Math.ceil(n / 8)) throw new Error('Out of bounds')
-    const m = new Array(n)
-    for (let i = 0; i < n; i += 8) {
-      const byte = state.buffer[state.start++]
-      for (let j = 0; j < 8 && i + j < n; j++) {
-        m[i + j] = (byte & (1 << j)) !== 0
-      }
-    }
-    return m
-  }
-}
-`
+const BOOL_ARRAY_ID = 'c.bitarray'
 
 module.exports = function generateSchema(hyperschema, { esm = false, filename } = {}) {
   const structs = []
@@ -44,8 +10,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
   const deferred = []
   const dedup = new Map()
   const externals = new Map()
-
-  let usesBoolArray = false
 
   for (let i = 0; i < hyperschema.schema.length; i++) {
     const fqn = hyperschema.typesByPosition.get(i)
@@ -126,11 +90,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
   str += '// eslint-disable-next-line no-unused-vars\n'
   str += 'let version = VERSION\n'
   str += '\n'
-
-  if (usesBoolArray) {
-    str += BOOL_ARRAY_ENCODER
-    str += '\n'
-  }
 
   for (let i = 0; i < structs.length; i++) {
     const struct = structs[i]
@@ -317,12 +276,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     return structsByName.get(type.fqn).id
   }
 
-  // arrays of bools are bitfields rather than an element per bool
-  function getBoolArrayEncoder() {
-    usesBoolArray = true
-    return BOOL_ARRAY_ID
-  }
-
   function dedupConst(name, def, deferred = false) {
     if (dedup.has(def)) return `const ${name} = ${dedup.get(def).name}\n`
     dedup.set(def, { deferred, name })
@@ -331,7 +284,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
   function getGeneratedFieldEncoder(field) {
     if (field.array && isBoolType(field.type)) {
-      return getBoolArrayEncoder()
+      return BOOL_ARRAY_ID
     }
 
     const typeStr = getGeneratedTypeEncoder(field.type)
@@ -454,7 +407,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     const boolArray = struct.isArray && isBoolType(struct.type)
 
     if (struct.isArray) {
-      enc = boolArray ? getBoolArrayEncoder() : getGeneratedTypeEncoder(struct.type)
+      enc = boolArray ? BOOL_ARRAY_ID : getGeneratedTypeEncoder(struct.type)
     } else if (struct.isRecord) {
       keyEnc = getGeneratedTypeEncoder(struct.key)
       enc = getGeneratedTypeEncoder(struct.value)

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -1,6 +1,6 @@
 const gen = require('generate-object-property')
 const s = require('generate-string')
-const { BitwiseNumericTypes, getBitwiseSize, getOptimizedEncoder } = require('./types.js')
+const { getOptimizedEncoder } = require('./types.js')
 
 module.exports = function generateSchema(hyperschema, { esm = false, filename } = {}) {
   const structs = []

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -1,6 +1,5 @@
 const gen = require('generate-object-property')
 const s = require('generate-string')
-const { getOptimizedEncoder } = require('./types.js')
 
 module.exports = function generateSchema(hyperschema, { esm = false, filename } = {}) {
   const structs = []
@@ -34,15 +33,19 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
   for (let i = 0; i < structs.length; i++) {
     const struct = structs[i]
-    // If optimized, use optimized "id"
-    const optimized = getOptimizedEncoder(struct)
-    const id = optimized ? optimized : 'encoding' + i
+    // If optimized, use the id the builder already resolved for it
+    const id = struct.optimizedEncoder ? struct.optimizedEncoder : 'encoding' + i
     const result = { encoder: null, id }
     structsByName.set(struct.fqn, result)
   }
   for (let i = 0; i < structs.length; i++) {
     const struct = structs[i]
     const result = structsByName.get(struct.fqn)
+
+    if (struct.optimizedEncoder) {
+      result.encoder = ''
+      continue
+    }
 
     if (struct.isExternal) {
       const v = requireExternal(struct, filename)
@@ -403,8 +406,6 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
     let keyEnc = ''
 
     if (struct.isArray) {
-      const optimized = getOptimizedEncoder(struct)
-      if (optimized) return '' // Already optimized away
       enc = getGeneratedTypeEncoder(struct.type)
     } else if (struct.isRecord) {
       keyEnc = getGeneratedTypeEncoder(struct.key)
@@ -414,12 +415,10 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
         const field = struct.fields[i]
         if (!field.framed && !field.array) continue
 
-        const optimized = getOptimizedEncoder(field)
-
         // already an existing compact-encoding reference - use it directly
         // rather than generating a local alias for it
-        if (optimized) {
-          fieldTypes.set(field.name, optimized)
+        if (field.optimizedEncoder) {
+          fieldTypes.set(field.name, field.optimizedEncoder)
           continue
         }
 

--- a/lib/codegen.js
+++ b/lib/codegen.js
@@ -34,7 +34,9 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
   for (let i = 0; i < structs.length; i++) {
     const struct = structs[i]
-    const id = 'encoding' + i
+    // If optimized, use optimized "id"
+    const optimized = getOptimizedEncoder(struct)
+    const id = optimized ? optimized : 'encoding' + i
     const result = { encoder: null, id }
     structsByName.set(struct.fqn, result)
   }
@@ -402,12 +404,7 @@ module.exports = function generateSchema(hyperschema, { esm = false, filename } 
 
     if (struct.isArray) {
       const optimized = getOptimizedEncoder(struct)
-      if (optimized) {
-        // already an existing compact-encoding reference - point every usage
-        // of this type directly at it instead of generating a local alias
-        structsByName.get(struct.fqn).id = optimized
-        return ''
-      }
+      if (optimized) return '' // Already optimized away
       enc = getGeneratedTypeEncoder(struct.type)
     } else if (struct.isRecord) {
       keyEnc = getGeneratedTypeEncoder(struct.key)

--- a/lib/types.js
+++ b/lib/types.js
@@ -59,9 +59,42 @@ function getDefaultValue(type) {
   return null
 }
 
+function isBoolType(type) {
+  if (type.isAlias) return isBoolType(type.type)
+  return !!type.bool
+}
+
+// Defines rules (aka match(type, ctx)) and an equivalent encoder
+// For example, hyperschema would generate c.array(c.bool) for a struct field
+// that's an array of bools. But c.bitarray could be used instead since the
+// array must be homogeneous and bools can be encoded efficiently as bits.
+// ctx describes how the type is being used: { array, record, framed }.
+// Add future equivalences here instead of special-casing them in codegen.
+const OptimizedEncoders = [
+  {
+    match: (type, ctx) => ctx.array && !ctx.record && !ctx.framed && isBoolType(type),
+    encoder: 'c.bitarray'
+  }
+]
+
+// node is a StructField or an array-type struct - anything exposing .type
+// plus the .array/.isArray, .record and .framed flags that describe its usage
+function getOptimizedEncoder(node) {
+  const ctx = {
+    array: !!(node.array || node.isArray),
+    record: !!node.record,
+    framed: !!node.framed
+  }
+  for (const { match, encoder } of OptimizedEncoders) {
+    if (match(node.type, ctx)) return encoder
+  }
+  return null
+}
+
 module.exports = {
   SupportedTypes,
   BitwiseNumericTypes,
   getDefaultValue,
-  getBitwiseSize
+  getBitwiseSize,
+  getOptimizedEncoder
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/holepunchto/hyperschema#readme",
   "dependencies": {
     "bare-fs": "^4.0.1",
-    "compact-encoding": "^3.0.0",
+    "compact-encoding": "^3.4.0",
     "generate-object-property": "^2.0.0",
     "generate-string": "^1.0.1"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -1563,3 +1563,51 @@ test('array of bools - bitwise uints cannot be arrays', async (t) => {
     /cannot be used as an array/
   )
 })
+
+test('array of bools - never framed', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'flag-array',
+      array: true,
+      type: 'bool'
+    })
+
+    ns.register({
+      name: 'indirect',
+      alias: '@test/flag-array'
+    })
+
+    // exercises both paths that could wrap an encoder in c.frame(): a field
+    // whose type resolves (through an alias) to a bool-array struct, and a
+    // field that is itself declared as an array of bools
+    ns.register({
+      name: 'has-flag-array',
+      fields: [
+        {
+          name: 'foo',
+          type: '@test/indirect',
+          required: true
+        },
+        {
+          name: 'bar',
+          type: 'bool',
+          array: true,
+          required: true
+        }
+      ]
+    })
+  })
+
+  const enc = schema.module.resolveStruct('@test/has-flag-array')
+  const expected = { foo: [true, false, true], bar: [false, true] }
+  const buf = c.encode(enc, expected)
+
+  // no flags bytes so: 03 05 (foo) 02 02 (bar)
+  // No framing bytes
+  t.is(buf.toString('hex'), '03050202', 'no framing overhead on either field')
+  t.alike(c.decode(enc, buf), expected)
+})

--- a/test/basic.js
+++ b/test/basic.js
@@ -1665,3 +1665,29 @@ test('array of bools - never framed', async (t) => {
   t.is(buf.toString('hex'), '03050202', 'no framing overhead on either field')
   t.alike(c.decode(enc, buf), expected)
 })
+
+test('array of bools - referenced before it is registered', async (t) => {
+  const schema = await createTestSchema(t)
+
+  await schema.rebuild((schema) => {
+    const ns = schema.namespace('test')
+
+    ns.register({
+      name: 'holder',
+      fields: [{ name: 'flags', type: '@test/flag-array', required: true }]
+    })
+
+    ns.register({
+      name: 'flag-array',
+      array: true,
+      type: 'bool'
+    })
+  })
+
+  const enc = schema.module.resolveStruct('@test/holder')
+  const expected = { flags: [true, false, true] }
+  const buf = c.encode(enc, expected)
+
+  t.is(buf.toString('hex'), '0305')
+  t.alike(c.decode(enc, buf), expected)
+})


### PR DESCRIPTION
This PR also includes a pattern to allow for future optimizations as well by defining a `match(type, ctx) => bool` function and an accompanying encoder string. Allows for replacing types with an optimized version with the only current implementation being an array of booleans which uses `c.bitarray`.

One quirk of this setup is that it can be applied to structs (such as the boolean arrays in the existing tests) so need to translate the `fqn` to the 'id' of the compact-encoding encoder, but don't need their own encoder implementation. So this required setting `encoder = ''` and skipping including the encoder being included in the normal output.

PR done with AI.